### PR TITLE
Make the fork work without the upstream repository

### DIFF
--- a/.github/workflows/build_sphinx.yml
+++ b/.github/workflows/build_sphinx.yml
@@ -1,11 +1,11 @@
 
 name: "Build Docs"
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   docs:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -25,7 +25,7 @@ jobs:
     # ===============================
     - name: Commit documentation changes
       run: |
-        git clone https://github.com/civviGH/django-testing-framework.git --branch gh-pages --single-branch gh-pages
+        git clone https://github.com/albertziegenhagel/django-testing-framework.git --branch gh-pages --single-branch gh-pages
         cp -r docs/_build/html/* gh-pages/
         cd gh-pages
         git config --local user.email "action@github.com"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -2,8 +2,8 @@ name: Upload Docs to gh-pages branch
 
 on:
   push:
-    branches:    
-      - master
+    branches:
+      - main
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Django Testing Framework
 
-[![Test Status](https://github.com/civviGH/django-testing-framework/workflows/Django%20CI/badge.svg?branch=master)](https://github.com/civviGH/django-testing-framework/actions?query=workflow%3A%22Django%20CI%22 "Tests Status")
-[![Coverage Status](https://coveralls.io/repos/github/civviGH/django-testing-framework/badge.svg?branch=master)](https://coveralls.io/github/civviGH/django-testing-framework?branch=master)
+[![Test Status](https://github.com/albertziegenhagel/django-testing-framework/workflows/Django%20CI/badge.svg?branch=master)](https://github.com/albertziegenhagel/django-testing-framework/actions?query=workflow%3A%22Django%20CI%22 "Tests Status")
+[![Coverage Status](https://coveralls.io/repos/github/albertziegenhagel/django-testing-framework/badge.svg?branch=master)](https://coveralls.io/github/albertziegenhagel/django-testing-framework?branch=master)
 
 ## Documentation
 
-The documentation is build using Sphinx and the Read-The-Docs Theme. The documentation is available online [here](https://civvigh.github.io/django-testing-framework/).
+The documentation is build using Sphinx and the Read-The-Docs Theme. The documentation is available online [here](https://albertziegenhagel.github.io/django-testing-framework/).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Test Status](https://github.com/albertziegenhagel/django-testing-framework/workflows/Django%20CI/badge.svg?branch=master)](https://github.com/albertziegenhagel/django-testing-framework/actions?query=workflow%3A%22Django%20CI%22 "Tests Status")
 [![Coverage Status](https://coveralls.io/repos/github/albertziegenhagel/django-testing-framework/badge.svg?branch=master)](https://coveralls.io/github/albertziegenhagel/django-testing-framework?branch=master)
 
+This is a fork of https://github.com/civviGH/django-testing-framework
+
 ## Documentation
 
 The documentation is build using Sphinx and the Read-The-Docs Theme. The documentation is available online [here](https://albertziegenhagel.github.io/django-testing-framework/).


### PR DESCRIPTION
The MR changes the CI to work on the `main` branch instead of the `master` branch.

`main` will be used as the default branch in this fork.

Additionally all references to the upstream repository are redirected to this repository.