### PR TITLE
Improve test reference update

### DIFF
--- a/dtf/views.py
+++ b/dtf/views.py
@@ -543,6 +543,7 @@ def project_reference_test(request, project_id, reference_id, test_id):
         return Response(serializer.data)
 
     elif request.method == 'PUT':
+        request.data['reference_set_id'] = reference_set.id
         serializer = TestReferenceSerializer(test_references, data=request.data)
         if serializer.is_valid():
             serializer.save()


### PR DESCRIPTION
The `ref_id` can now be included in the `references` JSON data field on post and put requests. The `test_id` datapoint is used as default `ref_id` for all measurements that do not include an explicit value. If all measurements include an explicit value, passing `test_id` is optional.

Please note, that only the `test_id` is validated against the database. This is for performance reasons, since checking all `ref_id` entries would result many database queries for tests with a lot of measurements. This is not that much of a problem, since an invalid `ref_id` should pose any dramatic problems to the whole database. It is already possible to have `ref_id` entries pointing to non-existent tests, when e.g. a test is being deleted after it has been marked as source for a given reference entry.
