### PR TITLE
Fix crash when using replace text for properties

### DIFF
--- a/dtf/templatetags/dtf/custom_filters.py
+++ b/dtf/templatetags/dtf/custom_filters.py
@@ -62,7 +62,7 @@ def submission_property(prop, submission):
         return ""
 
     if len(prop.display_replace) > 0:
-        replaced_value = prop.display_replace.replace("{VALUE}", value)
+        replaced_value = prop.display_replace.replace("{VALUE}", str(value))
     else:
         replaced_value = value
 


### PR DESCRIPTION
Explicitly convert value to string before using it in str.replace()

Values in the `info` dict of a submission can have different types than just `str` (e.g. they can be `int`). In this case we need to convert them to a string first, before using them in the `replace()` call.