### PR TITLE
Webhook fixes

### DIFF
--- a/dtf/tests/test_webhooks.py
+++ b/dtf/tests/test_webhooks.py
@@ -127,17 +127,18 @@ class WebhooksTest(TestCase):
             self.assertEqual(len(required_webhooks), 0)
 
         # Delete
-        with patch('dtf.webhooks.requests.Session.send', return_value=self._mock_response) as send_mock:
-            excepted_data = SubmissionSerializer(submission).data
-            submission.delete()
-            self.assertEqual(send_mock.call_count, 2)
+        if False:
+            with patch('dtf.webhooks.requests.Session.send', return_value=self._mock_response) as send_mock:
+                excepted_data = SubmissionSerializer(submission).data
+                submission.delete()
+                self.assertEqual(send_mock.call_count, 2)
 
-            required_webhooks = [self.all_webhook, self.submission_webhook]
+                required_webhooks = [self.all_webhook, self.submission_webhook]
 
-            self._check_webhook_submission(send_mock.call_args_list[0], Submission, 'delete', data, required_webhooks)
-            self._check_webhook_submission(send_mock.call_args_list[1], Submission, 'delete', data, required_webhooks)
+                self._check_webhook_submission(send_mock.call_args_list[0], Submission, 'delete', data, required_webhooks)
+                self._check_webhook_submission(send_mock.call_args_list[1], Submission, 'delete', data, required_webhooks)
 
-            self.assertEqual(len(required_webhooks), 0)
+                self.assertEqual(len(required_webhooks), 0)
 
     def test_on_test_result(self):
         submission = Submission(project=self.project)
@@ -173,17 +174,18 @@ class WebhooksTest(TestCase):
             self.assertEqual(len(required_webhooks), 0)
 
         # Delete
-        with patch('dtf.webhooks.requests.Session.send', return_value=self._mock_response) as send_mock:
-            data = TestResultSerializer(test_result).data
-            test_result.delete()
-            self.assertEqual(send_mock.call_count, 2)
+        if False:
+            with patch('dtf.webhooks.requests.Session.send', return_value=self._mock_response) as send_mock:
+                data = TestResultSerializer(test_result).data
+                test_result.delete()
+                self.assertEqual(send_mock.call_count, 2)
 
-            required_webhooks = [self.all_webhook, self.test_result_webhook]
+                required_webhooks = [self.all_webhook, self.test_result_webhook]
 
-            self._check_webhook_submission(send_mock.call_args_list[0], TestResult, 'delete', data, required_webhooks)
-            self._check_webhook_submission(send_mock.call_args_list[1], TestResult, 'delete', data, required_webhooks)
+                self._check_webhook_submission(send_mock.call_args_list[0], TestResult, 'delete', data, required_webhooks)
+                self._check_webhook_submission(send_mock.call_args_list[1], TestResult, 'delete', data, required_webhooks)
 
-            self.assertEqual(len(required_webhooks), 0)
+                self.assertEqual(len(required_webhooks), 0)
 
     def test_on_reference_set(self):
         submission = Submission(project=self.project)
@@ -220,17 +222,18 @@ class WebhooksTest(TestCase):
             self.assertEqual(len(required_webhooks), 0)
 
         # Delete
-        with patch('dtf.webhooks.requests.Session.send', return_value=self._mock_response) as send_mock:
-            data = ReferenceSetSerializer(reference_set).data
-            reference_set.delete()
-            self.assertEqual(send_mock.call_count, 2)
+        if False:
+            with patch('dtf.webhooks.requests.Session.send', return_value=self._mock_response) as send_mock:
+                data = ReferenceSetSerializer(reference_set).data
+                reference_set.delete()
+                self.assertEqual(send_mock.call_count, 2)
 
-            required_webhooks = [self.all_webhook, self.reference_set_webhook]
+                required_webhooks = [self.all_webhook, self.reference_set_webhook]
 
-            self._check_webhook_submission(send_mock.call_args_list[0], ReferenceSet, 'delete', data, required_webhooks)
-            self._check_webhook_submission(send_mock.call_args_list[1], ReferenceSet, 'delete', data, required_webhooks)
+                self._check_webhook_submission(send_mock.call_args_list[0], ReferenceSet, 'delete', data, required_webhooks)
+                self._check_webhook_submission(send_mock.call_args_list[1], ReferenceSet, 'delete', data, required_webhooks)
 
-            self.assertEqual(len(required_webhooks), 0)
+                self.assertEqual(len(required_webhooks), 0)
 
     def test_on_test_reference(self):
         submission = Submission(project=self.project)
@@ -275,14 +278,15 @@ class WebhooksTest(TestCase):
             self.assertEqual(len(required_webhooks), 0)
 
         # Delete
-        with patch('dtf.webhooks.requests.Session.send', return_value=self._mock_response) as send_mock:
-            data = TestReferenceSerializer(test_reference).data
-            test_reference.delete()
-            self.assertEqual(send_mock.call_count, 2)
+        if False:
+            with patch('dtf.webhooks.requests.Session.send', return_value=self._mock_response) as send_mock:
+                data = TestReferenceSerializer(test_reference).data
+                test_reference.delete()
+                self.assertEqual(send_mock.call_count, 2)
 
-            required_webhooks = [self.all_webhook, self.test_reference_webhook]
+                required_webhooks = [self.all_webhook, self.test_reference_webhook]
 
-            self._check_webhook_submission(send_mock.call_args_list[0], TestReference, 'delete', data, required_webhooks)
-            self._check_webhook_submission(send_mock.call_args_list[1], TestReference, 'delete', data, required_webhooks)
+                self._check_webhook_submission(send_mock.call_args_list[0], TestReference, 'delete', data, required_webhooks)
+                self._check_webhook_submission(send_mock.call_args_list[1], TestReference, 'delete', data, required_webhooks)
 
-            self.assertEqual(len(required_webhooks), 0)
+                self.assertEqual(len(required_webhooks), 0)

--- a/dtf/webhooks.py
+++ b/dtf/webhooks.py
@@ -121,7 +121,8 @@ def _on_model_save(sender, instance, created, **kwargs):
     trigger_webhooks('create' if created else 'edit', instance, sender)
 
 def _on_model_delete(sender, instance, **kwargs):
-    trigger_webhooks('delete', instance, sender)
+    # trigger_webhooks('delete', instance, sender)
+    pass
 
 def connect_webhook_signals():
     webhook_models = [Submission, TestResult, ReferenceSet, TestReference]

--- a/dtf/webhooks.py
+++ b/dtf/webhooks.py
@@ -106,14 +106,16 @@ def _serialize(instance):
         return TestReferenceSerializer(instance).data
 
 def trigger_webhooks(event, instance, sender):
-    data = {
-        'event' : event,
-        'source' : sender.__name__.lower(),
-        'project' : _serialize_project(instance),
-        'object' : _serialize(instance)
-    }
-    for webhook in _get_webhooks(instance):
-        trigger_webhook(webhook, data, sender)
+    webhooks = _get_webhooks(instance)
+    if webhooks.exists():
+        data = {
+            'event' : event,
+            'source' : sender.__name__.lower(),
+            'project' : _serialize_project(instance),
+            'object' : _serialize(instance)
+        }
+        for webhook in webhooks:
+            trigger_webhook(webhook, data, sender)
 
 def _on_model_save(sender, instance, created, **kwargs):
     trigger_webhooks('create' if created else 'edit', instance, sender)


### PR DESCRIPTION
This PR resolves to problems with the webhooks implementation:

- We do no longer serialize data for the webhooks POST request if there is no webhook to actually be executed.
- We disable executing webhooks on delete events (this is just a workaround and should be fixed properly in a future PR). The problem with webhooks on model deletion is that the model instance is not available anymore when the event is triggered and thus serialization of that instance for the POST payload can fail. Our current tests do not reproduce this behavior in the testing database and should be improved.