### PR TITLE
Introduce `duration` value type

### DIFF
--- a/dtf/models.py
+++ b/dtf/models.py
@@ -130,6 +130,7 @@ class TestResult(models.Model):
                         'integer',
                         'float',
                         'string',
+                        'duration',
                         'ndarray',
                         'image'
                     ]
@@ -158,6 +159,20 @@ class TestResult(models.Model):
                 },
                 'then': {
                     'properties': {'data': {'type': 'string'}}
+                }
+            },
+            {
+                'if': {
+                    'properties': {'type': {'const': 'duration'}}
+                },
+                'then': {
+                    'properties': {
+                        'data': {
+                            'type': 'string',
+                            # ISO 8601 duration
+                            'pattern': R'^(?P<sign>[-+]?)P(?:(?P<days>\d+(\.\d+)?)D)?(?:T(?:(?P<hours>\d+(\.\d+)?)H)?(?:(?P<minutes>\d+(\.\d+)?)M)?(?:(?P<seconds>\d+(\.\d+)?)S)?)?$'
+                        }
+                    }
                 }
             },
             {

--- a/dtf/templatetags/dtf/custom_filters.py
+++ b/dtf/templatetags/dtf/custom_filters.py
@@ -8,6 +8,7 @@ from django import template
 from django.template import Context
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
+from django.utils.dateparse import parse_duration
 from django import forms
 
 from dtf.settings import STATUS_TEXT_COLORS
@@ -58,6 +59,8 @@ def create_html_representation(data, valuetype):
     if valuetype == "list": # backward-compatibility
         out = " <br> ".join(str(data).strip("[]").split(","))
         return mark_safe(out)
+    if valuetype == "duration":
+        return str(parse_duration(data))
     if valuetype == "ndarray":
         shape = data['shape']
         entries = [str(create_html_representation(entry['data'], entry['type'])) for entry in data['entries']]

--- a/dtf/tests/test_api.py
+++ b/dtf/tests/test_api.py
@@ -503,6 +503,13 @@ class TestResultsApiTest(ApiTestCase):
                         "type" : "ndarray"
                     },
                 },
+                {
+                    "name": "parameter8",
+                    "value" : {
+                        "data" : "P400DT3H5.5M",
+                        "type" : "duration"
+                    },
+                },
             ],
         }
 
@@ -556,6 +563,11 @@ class TestResultsApiTest(ApiTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         invalid_payload["results"][0]["value"] = { 'data' : 'not_a_number', 'type' : 'float' }
+        response, data = self.post(self.url, invalid_payload)
+        self.assertEqual(TestResult.objects.count(), 0)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        invalid_payload["results"][0]["value"] = { 'data' : 'not_a_timedelta', 'type' : 'duration' }
         response, data = self.post(self.url, invalid_payload)
         self.assertEqual(TestResult.objects.count(), 0)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/dtf/tests/test_filters.py
+++ b/dtf/tests/test_filters.py
@@ -36,6 +36,16 @@ class ValueHtmlRepresentationTestCase(TestCase):
         result = create_html_representation(image_base64, 'image')
         self.assertEqual(result, f"<img src='data:image/png;base64, {image_base64}' />")
 
+    def test_duration(self):
+        result = create_html_representation("P400DT3H5.5M", 'duration')
+        self.assertEqual(result, f"400 days, 3:05:30")
+
+        result = create_html_representation("PT1M1.23S", 'duration')
+        self.assertEqual(result, f"0:01:01.230000")
+
+        result = create_html_representation("PT0.4567S", 'duration')
+        self.assertEqual(result, f"0:00:00.456700")
+
     def test_ndarray_vector(self):
         data = {
             "shape" : [ 2 ],


### PR DESCRIPTION
This allows us to handle time durations (Python `datetime.timedelta`) more explicitly (e.g. render them more nicely in the results tables).

Times are stored and transferred as ISO 8601 compatible strings. E.g. `PT1M1.23S`.