### PR TITLE
Fix badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Django Testing Framework
 
-[![Test Status](https://github.com/albertziegenhagel/django-testing-framework/workflows/Django%20CI/badge.svg?branch=master)](https://github.com/albertziegenhagel/django-testing-framework/actions?query=workflow%3A%22Django%20CI%22 "Tests Status")
-[![Coverage Status](https://coveralls.io/repos/github/albertziegenhagel/django-testing-framework/badge.svg?branch=master)](https://coveralls.io/github/albertziegenhagel/django-testing-framework?branch=master)
+[![Test Status](https://github.com/albertziegenhagel/django-testing-framework/workflows/Django%20CI/badge.svg?branch=main)](https://github.com/albertziegenhagel/django-testing-framework/actions?query=workflow%3A%22Django%20CI%22 "Tests Status")
+[![Coverage Status](https://coveralls.io/repos/github/albertziegenhagel/django-testing-framework/badge.svg?branch=main)](https://coveralls.io/github/albertziegenhagel/django-testing-framework?branch=main)
 
 This is a fork of https://github.com/civviGH/django-testing-framework
 


### PR DESCRIPTION
Fix badges to point to the `main` instead of the `master` branch.