### PR TITLE
Improve Status computation for tests/submissions

### DIFF
--- a/dtf/models.py
+++ b/dtf/models.py
@@ -273,12 +273,12 @@ class TestResult(models.Model):
     status = models.CharField(choices=POSSIBLE_STATUS, default="unknown", max_length=20)
 
     status_order = {
-        "skip":0,
-        "successful": 10,
-        "unstable": 20,
-        "failed": 30,
-        "unknown": 40,
-        "broken": 50
+        "skip": 0,
+        "successful": 1,
+        "unknown": 2,
+        "unstable": 3,
+        "failed": 4,
+        "broken": 5
     }
 
     def calculate_status(self):

--- a/dtf/models.py
+++ b/dtf/models.py
@@ -105,11 +105,13 @@ class Submission(models.Model):
     info = models.JSONField(null=False, default=dict, validators=[JSONSchemaValidator(schema=_info_json_schema)])
 
     def status(self):
-        status = "successful"
+        status = None
         for test in self.tests.all():
             test_status = test.status
-            if TestResult.status_order[test_status] > TestResult.status_order[status]:
+            if status is None or TestResult.status_order[test_status] > TestResult.status_order[status]:
                 status = test_status
+        if status is None:
+            return "unknown"
         return status
 
     class Meta:
@@ -282,11 +284,14 @@ class TestResult(models.Model):
     }
 
     def calculate_status(self):
-        status = "successful"
+        status = None
         for result in self.results:
-            if self.status_order[result['status']] > self.status_order[status]:
+            if status is None or self.status_order[result['status']] > self.status_order[status]:
                 status = result['status']
-        self.status = status
+        if status is None:
+            self.status = "unknown"
+        else:
+            self.status = status
 
     def save(self, *args, **kwargs):
         self.calculate_status()


### PR DESCRIPTION
This introduces two changes to how we compute the status of tests and submissions:
- "unstable" and "failed" statuses are now ordered higher than "unknown".
The reasoning is as follows: if we have an unstable or failed test measurement, we do actually have some information about the test itself, thus it should not be "unknown".
- Empty tests and submissions are not "successful" anymore, but will get an "unknown" status.
This is more desirable in most use cases, since empty tests/submission usually indicate that something is not being executed correctly (why else should we provide that information at all?!). Having those tests/submissions being marked successful, might lead to the impression that everything was alright, and we might miss some errors.
