### PR TITLE
Disable history navigation bar in test details view

### DIFF
--- a/dtf/templates/dtf/test_result_details.html
+++ b/dtf/templates/dtf/test_result_details.html
@@ -123,7 +123,7 @@ function toggleAllBoxes(){
 <div class="page-header mb-5">
     {# <h2 class="my-auto float-left">{{ test_result.name }} [{{ test_result.submission.pk }}]</h2> #}
 
-    {% if nav_data.previous.exists %}
+    {% comment %} {% if nav_data.previous.exists %}
     <a href="{% url 'test_result_details' nav_data.previous.id %}" class="btn btn-sm btn-primary active mr-1 float-left">Previous</a> 
     {% else %}
     <a href="#" class="btn btn-sm btn-secondary mr-1 float-left disabled">Previous</a> 
@@ -139,11 +139,11 @@ function toggleAllBoxes(){
     <a href="#" class="btn btn-sm btn-secondary mr-1 float-left disabled">>></a>  
     {% else %}
     <a href="{% url 'test_result_details' nav_data.most_recent.id %}" class="btn btn-sm btn-primary active mr-1 float-left">>></a>
-    {% endif %}
+    {% endif %} {% endcomment %}
 
     {% with not_successful=test_result.get_next_not_successful_test_id %}
     {% if not_successful is None %}
-    <a href="#" class="ml-4 btn btn-sm btn-secondary mr-1 float-left disabled">Next not successful</a>  
+    <a href="#" class="btn btn-sm btn-secondary mr-1 float-left disabled">Next not successful</a>  
     {% else %}
     <a href="{% url 'test_result_details' not_successful %}" class="ml-4 btn btn-sm btn-info active mr-1 float-left">Next not successful</a>
     {% endif %}

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -162,7 +162,7 @@ def view_test_result_details(request, test_id):
         references = {}
 
     data = create_view_data_from_test_references(test_result.results, references)
-    nav_data = project.get_nav_data(test_result.name, test_result.submission.id)
+    # nav_data = project.get_nav_data(test_result.name, test_result.submission.id)
     return render(request, 'dtf/test_result_details.html', {
         'project':project,
         'reference_set':reference_set,
@@ -170,7 +170,7 @@ def view_test_result_details(request, test_id):
         'test_result':test_result,
         'property_values':str(property_values),
         'data':data,
-        'nav_data':nav_data
+        # 'nav_data':nav_data
     })
 
 def view_submission_details(request, submission_id):


### PR DESCRIPTION
Getting the navigation data from the DB is very slow and might make loading the webpage fail with a timeout on instances with a huge amount of test entries.

The most probable reason for the performance problem is this code part:

https://github.com/albertziegenhagel/django-testing-framework/blob/3b5092477608d5cd3b7971b828f68138c3d8b858/dtf/models.py#L37-L40

where we have to filter over ALL TestResult objects in the DB.

Maybe this could be implemented by using https://docs.djangoproject.com/en/3.1/ref/models/instances/#django.db.models.Model.get_previous_by_FOO or something similar.