### PR TITLE
Refactor view URLs

### DIFF
--- a/dtf/api.py
+++ b/dtf/api.py
@@ -25,11 +25,11 @@ from dtf.functions import get_project_by_id_or_slug, create_reference_query
 def projects(request):
     if request.method == 'GET':
         projects = Project.objects.order_by('-pk')
-        serializer = ProjectSerializer(projects, many=True)
+        serializer = ProjectSerializer(projects, many=True, context={"request": request})
         return Response(serializer.data, status.HTTP_200_OK)
 
     elif request.method == 'POST':
-        serializer = ProjectSerializer(data=request.data)
+        serializer = ProjectSerializer(data=request.data, context={"request": request})
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -42,11 +42,11 @@ def project(request, id):
         return Response(status=status.HTTP_404_NOT_FOUND)
 
     if request.method == 'GET':
-        serializer = ProjectSerializer(project)
+        serializer = ProjectSerializer(project, context={"request": request})
         return Response(serializer.data)
 
     elif request.method == 'PUT':
-        serializer = ProjectSerializer(project, data=request.data)
+        serializer = ProjectSerializer(project, data=request.data, context={"request": request})
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data)
@@ -178,12 +178,12 @@ def project_submissions(request, project_id):
 
     if request.method == 'GET':
         submissions = Submission.objects.filter(project=project).order_by('-pk')
-        serializer = SubmissionSerializer(submissions, many=True)
+        serializer = SubmissionSerializer(submissions, many=True, context={"request": request})
         return Response(serializer.data, status.HTTP_200_OK)
 
     elif request.method == 'POST':
         request.data['project'] = project.id
-        serializer = SubmissionSerializer(data=request.data)
+        serializer = SubmissionSerializer(data=request.data, context={"request": request})
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -200,11 +200,11 @@ def project_submission(request, project_id, submission_id):
         return Response(status=status.HTTP_404_NOT_FOUND)
 
     if request.method == 'GET':
-        serializer = SubmissionSerializer(submission)
+        serializer = SubmissionSerializer(submission, context={"request": request})
         return Response(serializer.data)
 
     elif request.method == 'PUT':
-        serializer = SubmissionSerializer(submission, data=request.data)
+        serializer = SubmissionSerializer(submission, data=request.data, context={"request": request})
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data)
@@ -230,12 +230,12 @@ def project_submission_tests(request, project_id, submission_id):
 
     if request.method == 'GET':
         tests = TestResult.objects.filter(submission=submission).order_by('-pk')
-        serializer = TestResultSerializer(tests, many=True)
+        serializer = TestResultSerializer(tests, many=True, context={"request": request})
         return Response(serializer.data, status.HTTP_200_OK)
 
     elif request.method == 'POST':
         request.data['submission'] = submission.id
-        serializer = TestResultSerializer(data=request.data)
+        serializer = TestResultSerializer(data=request.data, context={"request": request})
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -256,11 +256,11 @@ def project_submission_test(request, project_id, submission_id, test_id):
         return Response(status=status.HTTP_404_NOT_FOUND)
 
     if request.method == 'GET':
-        serializer = TestResultSerializer(test)
+        serializer = TestResultSerializer(test, context={"request": request})
         return Response(serializer.data)
 
     elif request.method == 'PUT':
-        serializer = TestResultSerializer(test, data=request.data)
+        serializer = TestResultSerializer(test, data=request.data, context={"request": request})
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data)

--- a/dtf/templates/dtf/project_details.html
+++ b/dtf/templates/dtf/project_details.html
@@ -47,7 +47,7 @@
     </thead>
     <tbody>
     {% for submission in submissions|dictsortreversed:"id" %}
-    <tr onclick="window.location='{% url 'submission_details' submission.pk %}';" style="cursor:pointer">
+    <tr onclick="window.location='{% url 'submission_details' project.slug submission.pk %}';" style="cursor:pointer">
         <td>
             {{ submission.status|status_badge }}
         </td>

--- a/dtf/templates/dtf/submission_details.html
+++ b/dtf/templates/dtf/submission_details.html
@@ -44,7 +44,7 @@
     </thead>
     <tbody>
     {% for test in submission.tests.all %}
-    <tr onclick="window.location='{% url 'test_result_details' test.pk %}'" style="cursor:pointer">
+    <tr onclick="window.location='{% url 'test_result_details' submission.project.slug test.pk %}'" style="cursor:pointer">
         <td>
             {{ test.status|status_badge }}
         </td>

--- a/dtf/templates/dtf/test_result_details.html
+++ b/dtf/templates/dtf/test_result_details.html
@@ -109,7 +109,7 @@ function toggleAllBoxes(){
         <a href="{% url 'project_details' test_result.submission.project.slug %}">{{ project.name }}</a>
     </li>
     <li class="breadcrumb-item" aria-current="page">
-        <a href="{% url 'submission_details' test_result.submission.pk %}">
+        <a href="{% url 'submission_details' test_result.submission.project.slug test_result.submission.pk %}">
         Submission {{test_result.submission.id}} | {{test_result.submission.created}}
         </a>
     </li>
@@ -124,13 +124,13 @@ function toggleAllBoxes(){
     {# <h2 class="my-auto float-left">{{ test_result.name }} [{{ test_result.submission.pk }}]</h2> #}
 
     {% comment %} {% if nav_data.previous.exists %}
-    <a href="{% url 'test_result_details' nav_data.previous.id %}" class="btn btn-sm btn-primary active mr-1 float-left">Previous</a> 
+    <a href="{% url 'test_result_details' test_result.submission.project.slug nav_data.previous.id %}" class="btn btn-sm btn-primary active mr-1 float-left">Previous</a> 
     {% else %}
     <a href="#" class="btn btn-sm btn-secondary mr-1 float-left disabled">Previous</a> 
     {% endif %}
 
     {% if nav_data.next.exists %}
-    <a href="{% url 'test_result_details' nav_data.next.id %}" class="btn btn-sm btn-primary active mr-1 float-left">Next</a>
+    <a href="{% url 'test_result_details' test_result.submission.project.slug nav_data.next.id %}" class="btn btn-sm btn-primary active mr-1 float-left">Next</a>
     {% else %}
     <a href="#" class="btn btn-sm btn-secondary mr-1 float-left disabled">Next</a>  
     {% endif %}
@@ -138,14 +138,14 @@ function toggleAllBoxes(){
     {% if nav_data.most_recent.id == test_result.id %}
     <a href="#" class="btn btn-sm btn-secondary mr-1 float-left disabled">>></a>  
     {% else %}
-    <a href="{% url 'test_result_details' nav_data.most_recent.id %}" class="btn btn-sm btn-primary active mr-1 float-left">>></a>
+    <a href="{% url 'test_result_details' test_result.submission.project.slug nav_data.most_recent.id %}" class="btn btn-sm btn-primary active mr-1 float-left">>></a>
     {% endif %} {% endcomment %}
 
     {% with not_successful=test_result.get_next_not_successful_test_id %}
     {% if not_successful is None %}
     <a href="#" class="btn btn-sm btn-secondary mr-1 float-left disabled">Next not successful</a>  
     {% else %}
-    <a href="{% url 'test_result_details' not_successful %}" class="ml-4 btn btn-sm btn-info active mr-1 float-left">Next not successful</a>
+    <a href="{% url 'test_result_details' test_result.submission.project.slug not_successful %}" class="ml-4 btn btn-sm btn-info active mr-1 float-left">Next not successful</a>
     {% endif %}
     {% endwith %}
 
@@ -198,7 +198,7 @@ function toggleAllBoxes(){
             <td>
                 {% if parameter.reference_on_submission %}
                     {% if parameter.reference_on_submission_source %}
-                        <a class="ref_link" target="_blank" href="{% url 'test_result_details' parameter.reference_on_submission_source %}">{{ parameter.reference_on_submission.data|create_html_representation:parameter.reference_on_submission.type }}</a>
+                        <a class="ref_link" target="_blank" href="{% url 'test_result_details' test_result.submission.project.slug parameter.reference_on_submission_source %}">{{ parameter.reference_on_submission.data|create_html_representation:parameter.reference_on_submission.type }}</a>
                     {% else %}
                         {{ parameter.reference_on_submission.data|create_html_representation:parameter.reference_on_submission.type }}
                     {% endif %}
@@ -209,7 +209,7 @@ function toggleAllBoxes(){
             <td>
                 {% if parameter.reference %}
                     {% if parameter.reference_source %}
-                        <a class="ref_link" target="_blank" href="{% url 'test_result_details' parameter.reference_source %}">{{ parameter.reference.data|create_html_representation:parameter.reference.type }}</a>
+                        <a class="ref_link" target="_blank" href="{% url 'test_result_details' test_result.submission.project.slug parameter.reference_source %}">{{ parameter.reference.data|create_html_representation:parameter.reference.type }}</a>
                     {% else %}
                         {{ parameter.reference.data|create_html_representation:parameter.reference.type }}
                     {% endif %}

--- a/dtf/tests/test_api.py
+++ b/dtf/tests/test_api.py
@@ -123,7 +123,7 @@ class ProjectsApiTest(ApiTestCase):
         _ = self.create_project('Test/Project#?3')
         response = client.get(reverse('api_projects'))
         projects = Project.objects.order_by('-pk')
-        serializer = ProjectSerializer(projects, many=True)
+        serializer = ProjectSerializer(projects, many=True, context={"request": response.wsgi_request})
         self.assertEqual(response.data, serializer.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -144,23 +144,23 @@ class ProjectApiTest(ApiTestCase):
     def test_get_project_id(self):
         response = client.get(reverse('api_project', kwargs={'id' : self.project_1_id}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        serializer = ProjectSerializer(self.project_1)
+        serializer = ProjectSerializer(self.project_1, context={"request": response.wsgi_request})
         self.assertEqual(response.data, serializer.data)
 
         response = client.get(reverse('api_project', kwargs={'id' : self.project_2_id}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        serializer = ProjectSerializer(self.project_2)
+        serializer = ProjectSerializer(self.project_2, context={"request": response.wsgi_request})
         self.assertEqual(response.data, serializer.data)
 
     def test_get_project_slug(self):
         response = client.get(reverse('api_project', kwargs={'id' : self.project_1_slug}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        serializer = ProjectSerializer(self.project_1)
+        serializer = ProjectSerializer(self.project_1, context={"request": response.wsgi_request})
         self.assertEqual(response.data, serializer.data)
 
         response = client.get(reverse('api_project', kwargs={'id' : self.project_2_slug}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        serializer = ProjectSerializer(self.project_2)
+        serializer = ProjectSerializer(self.project_2, context={"request": response.wsgi_request})
         self.assertEqual(response.data, serializer.data)
 
     def test_get_project_invalid(self):
@@ -355,7 +355,7 @@ class SubmissionsApiTest(ApiTestCase):
         self.create_submission(project_id=self.project_id, info={"Key": "Value"})
         response = client.get(reverse('api_project_submissions', kwargs={'project_id' : self.project_id}))
         submissions = Submission.objects.order_by('-pk')
-        serializer = SubmissionSerializer(submissions, many=True)
+        serializer = SubmissionSerializer(submissions, many=True, context={"request": response.wsgi_request})
         self.assertEqual(response.data, serializer.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -377,12 +377,12 @@ class SubmissionApiTest(ApiTestCase):
     def test_get(self):
         response = client.get(self.url_1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        serializer = SubmissionSerializer(self.submission_1)
+        serializer = SubmissionSerializer(self.submission_1, context={"request": response.wsgi_request})
         self.assertEqual(response.data, serializer.data)
 
         response = client.get(self.url_2)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        serializer = SubmissionSerializer(self.submission_2)
+        serializer = SubmissionSerializer(self.submission_2, context={"request": response.wsgi_request})
         self.assertEqual(response.data, serializer.data)
 
     def test_get_invalid(self):
@@ -597,7 +597,7 @@ class TestResultsApiTest(ApiTestCase):
         response, data = self.post(self.url, self.small_valid_payload)
         response = client.get(self.url)
         tests = TestResult.objects.order_by('-pk')
-        serializer = TestResultSerializer(tests, many=True)
+        serializer = TestResultSerializer(tests, many=True, context={"request": response.wsgi_request})
         self.assertEqual(response.data, serializer.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -622,12 +622,12 @@ class TestResultApiTest(ApiTestCase):
     def test_get(self):
         response = client.get(self.url_1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        serializer = TestResultSerializer(self.test_1)
+        serializer = TestResultSerializer(self.test_1, context={"request": response.wsgi_request})
         self.assertEqual(response.data, serializer.data)
 
         response = client.get(self.url_2)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        serializer = TestResultSerializer(self.test_2)
+        serializer = TestResultSerializer(self.test_2, context={"request": response.wsgi_request})
         self.assertEqual(response.data, serializer.data)
 
     def test_get_invalid(self):

--- a/dtf/urls.py
+++ b/dtf/urls.py
@@ -3,6 +3,7 @@ define the URLs for the project
 """
 
 from rest_framework.urlpatterns import format_suffix_patterns
+from django.views.generic import RedirectView
 from django.urls import path
 from django.contrib import admin
 from dtf import views
@@ -11,7 +12,7 @@ from dtf import api
 urlpatterns = [
     path('admin/', admin.site.urls),
 
-    path('', views.frontpage),
+    path('', RedirectView.as_view(pattern_name='projects', permanent=False)),
     path('projects/', views.view_projects, name='projects'),
     path('projects/new', views.view_new_project, name='new_project'),
     path('<str:project_slug>', views.view_project_details, name='project_details'),

--- a/dtf/urls.py
+++ b/dtf/urls.py
@@ -18,8 +18,8 @@ urlpatterns = [
     path('<str:project_slug>', views.view_project_details, name='project_details'),
     path('<str:project_slug>/settings', views.view_project_settings, name='project_settings'),
     path('<str:project_slug>/webhook/<int:webhook_id>/log', views.view_webhook_log, name='webhook_log'),
-    path('submission_details/<int:submission_id>', views.view_submission_details, name='submission_details'),
-    path('test_details/<int:test_id>', views.view_test_result_details, name='test_result_details'),
+    path('<str:project_slug>/submissions/<int:submission_id>', views.view_submission_details, name='submission_details'),
+    path('<str:project_slug>/tests/<int:test_id>', views.view_test_result_details, name='test_result_details'),
 
     path('api/projects', api.projects, name='api_projects'),
     path('api/projects/<str:id>', api.project, name='api_project'),

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -49,7 +49,7 @@ def view_project_settings(request, project_slug):
 
             if project_form.is_valid():
                 project_form.save()
-                serializer = ProjectSerializer(project_form.instance)
+                serializer = ProjectSerializer(project_form.instance, context={"request": request})
                 return JsonResponse({'result' : 'valid', 'property' : serializer.data})
             else:
                 data = project_form.errors.get_json_data()

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -1,7 +1,7 @@
 
 from django.core.paginator import Paginator
 from django.shortcuts import render, get_object_or_404
-from django.http import HttpResponseRedirect, JsonResponse, HttpResponse
+from django.http import HttpResponseRedirect, JsonResponse, HttpResponse, Http404
 from django.urls import reverse
 
 from rest_framework import status
@@ -131,10 +131,12 @@ def view_project_details(request, project_slug):
         'submissions':submissions
     })
 
-def view_test_result_details(request, test_id):
+def view_test_result_details(request, project_slug, test_id):
+    project = get_object_or_404(Project, slug=project_slug)
     test_result = get_object_or_404(TestResult, pk=test_id)
     submission = test_result.submission
-    project = submission.project
+    if submission.project != project:
+        raise Http404("The test does not belong to this project")
 
     queries = create_reference_query(project, submission.info)
 
@@ -173,8 +175,11 @@ def view_test_result_details(request, test_id):
         # 'nav_data':nav_data
     })
 
-def view_submission_details(request, submission_id):
+def view_submission_details(request, project_slug, submission_id):
+    project = get_object_or_404(Project, slug=project_slug)
     submission = get_object_or_404(Submission, pk=submission_id)
+    if submission.project != project:
+        raise Http404("The submission does not belong to this project")
     return render(request, 'dtf/submission_details.html', {
         'submission':submission
     })


### PR DESCRIPTION
This MR changes the URLs for the submission and test detail pages from

    http://example.dtf.com/submission_details/123
    http://example.dtf.com/test_details/456

to

    http://example.dtf.com/demo-project/submissions/123
    http://example.dtf.com/demo-project/tests/456

which basically moves the URLs into the project scope and removes the underscores in the URLs.

Additionally the URLs for projects, submissions and test results are now included in the API requests JSON response.

E.g. `curl -s 127.0.0.1:8000/api/projects/demo` would return something like

```
{
    "id": 8,
    "name": "Demo Project",
    "slug": "demo",
    "created": "2020-12-11T11:02:24.581967Z",
    "last_updated": "2020-12-14T16:29:58.352884Z",
    "url": "http://127.0.0.1:8000/demo"
}
```

which can be used by down-stream tools to create a link to the projects webpage.

