### PR TITLE
Add views for the reference sets of a project

### DIFF
--- a/dtf/templates/dtf/project_reference_sets.html
+++ b/dtf/templates/dtf/project_reference_sets.html
@@ -1,0 +1,68 @@
+{% extends 'dtf/base.html' %}
+
+{% load dtf.custom_filters %}
+
+{% block body %}
+
+<div class="bg-white sticky-top pt-3 pb-1">
+
+<nav>
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'projects' %}">Project List</a>
+    </li>
+    <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'project_details' project.slug %}">{{ project.name }}</a>
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">Reference Sets</li>
+  </ol>
+</nav>
+
+</div>
+
+<div class="page-header">
+    <h2 class="float-left">Reference Sets</h2>
+</div>
+
+<table class="table table-hover">
+    <thead>
+    <tr>
+        <th class="noselect">
+            ID
+        </th>
+        <th class="noselect">
+            Created on
+        </th>
+        {% for property in properties %}
+            {% if property.influence_reference %}
+                <th class="noselect">
+                    {{ property.name }}
+                </th>
+            {% endif %}
+        {% endfor %}
+    </tr>
+    </thead>
+    <tbody>
+    {% for reference_set in reference_sets %}
+    <tr onclick="window.location='{% url 'reference_set_details' project.slug reference_set.pk %}';" style="cursor:pointer">
+        <td>
+            {{ reference_set.pk }}
+        </td>
+        <td>
+            {{ reference_set.created }}
+        </td>
+        {% for property in properties %}
+            {% if property.influence_reference %}
+                <td>
+                    {{ property|reference_property:reference_set }}
+                </td>
+            {% endif %}
+        {% endfor %}
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+{% include "dtf/bootstrap/paginator.html" with page_obj=reference_sets %}
+
+{% endblock %}

--- a/dtf/templates/dtf/project_submissions.html
+++ b/dtf/templates/dtf/project_submissions.html
@@ -11,7 +11,10 @@
     <li class="breadcrumb-item" aria-current="page">
         <a href="{% url 'projects' %}">Project List</a>
     </li>
-    <li class="breadcrumb-item active" aria-current="page">{{project.name}}</li>
+    <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'project_details' project.slug %}">{{ project.name }}</a>
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">Submissions</li>
   </ol>
 </nav>
 

--- a/dtf/templates/dtf/reference_set_details.html
+++ b/dtf/templates/dtf/reference_set_details.html
@@ -1,0 +1,57 @@
+{% extends 'dtf/base.html' %}
+
+{% load dtf.custom_filters %}
+
+{% block body %}
+
+<div class="bg-white sticky-top pt-3 pb-1">
+
+<nav>
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'projects' %}">Project List</a>
+    </li>
+    <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'project_details' reference_set.project.slug %}">{{reference_set.project.name}}</a>
+    </li>
+    <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'project_reference_sets' reference_set.project.slug %}">Reference Sets</a>
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">{{reference_set.id}}</li>
+  </ol>
+</nav>
+
+<div class="page-header">
+    <div class="w-100">
+        <h2>Test References</h2>
+    </div>
+</div>
+
+</div>
+
+<table class="table table-hover tablesorter">
+    <thead>
+    <tr>
+        <th class="noselect">
+            Test Name
+        </th>
+        <th class="noselect">
+            Date
+        </th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for test in reference_set.test_references.all %}
+    <tr onclick="window.location='{% url 'test_reference_details' reference_set.project.slug test.pk %}'" style="cursor:pointer">
+        <td>
+            {{ test.test_name }}
+        </td>
+        <td>
+            {{ test.created }}
+        </td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+{% endblock %}

--- a/dtf/templates/dtf/submission_details.html
+++ b/dtf/templates/dtf/submission_details.html
@@ -14,7 +14,10 @@
     <li class="breadcrumb-item" aria-current="page">
         <a href="{% url 'project_details' submission.project.slug %}">{{submission.project.name}}</a>
     </li>
-    <li class="breadcrumb-item active" aria-current="page">Submission {{submission.id}} | {{submission.created}}</li>
+    <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'project_submissions' submission.project.slug %}">Submissions</a>
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">{{submission.id}} | {{submission.created}}</li>
   </ol>
 </nav>
 

--- a/dtf/templates/dtf/test_reference_details.html
+++ b/dtf/templates/dtf/test_reference_details.html
@@ -1,0 +1,69 @@
+{% extends 'dtf/base.html' %}
+
+{% load dtf.custom_filters %}
+{% block body %}
+
+<div class="bg-white sticky-top pt-3 pb-1">
+
+<nav>
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'projects' %}">Project List</a>
+    </li>
+    <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'project_details' test_reference.reference_set.project.slug %}">{{ test_reference.reference_set.project.name }}</a>
+    </li>
+    <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'project_reference_sets' test_reference.reference_set.project.slug %}">Reference Sets</a>
+    </li>
+    <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'reference_set_details' test_reference.reference_set.project.slug test_reference.reference_set.pk %}">
+        {{test_reference.reference_set.id}}
+        </a>
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">
+        {{ test_reference.test_name }}
+    </li>
+  </ol>
+</nav>
+
+</div>
+
+<table class="table table-striped table-hover table-sm tablesorter">
+    <thead>
+    <tr>
+        <th class="noselect">
+            Name
+        </th>
+        <th class="noselect">
+            Value
+        </th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for name, entry in test_reference.references.items %}
+        <tr>
+            <td>
+                {{ name }}
+            </td>
+            <td>
+                {% if entry.value %}
+                    {% if entry.source %}
+                        <a class="ref_link" target="_blank" href="{% url 'test_result_details' test_reference.reference_set.project.slug entry.source %}">{{ entry.value.data|create_html_representation:entry.value.type }}</a>
+                    {% else %}
+                        {{ entry.value.data|create_html_representation:entry.value.type }}
+                    {% endif %}
+                {% else %}
+                    {% if entry.source %}
+                        <a class="ref_link" target="_blank" href="{% url 'test_result_details' test_reference.reference_set.project.slug entry.source %}">N/A</a>
+                    {% else %}
+                        N/A
+                    {% endif %}
+                {% endif %}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+{% endblock %}

--- a/dtf/templates/dtf/test_result_details.html
+++ b/dtf/templates/dtf/test_result_details.html
@@ -109,8 +109,11 @@ function toggleAllBoxes(){
         <a href="{% url 'project_details' test_result.submission.project.slug %}">{{ project.name }}</a>
     </li>
     <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'project_submissions' test_result.submission.project.slug %}">Submissions</a>
+    </li>
+    <li class="breadcrumb-item" aria-current="page">
         <a href="{% url 'submission_details' test_result.submission.project.slug test_result.submission.pk %}">
-        Submission {{test_result.submission.id}} | {{test_result.submission.created}}
+        {{test_result.submission.id}} | {{test_result.submission.created}}
         </a>
     </li>
     <li class="breadcrumb-item active" aria-current="page">

--- a/dtf/templatetags/dtf/custom_filters.py
+++ b/dtf/templatetags/dtf/custom_filters.py
@@ -90,9 +90,7 @@ def create_html_representation(data, valuetype):
         return mark_safe(out)
     return str(data)
 
-@register.filter
-def submission_property(prop, submission):
-    value = submission.info.get(prop.name, None)
+def _as_property(prop, value):
     if value is None:
         return ""
 
@@ -105,6 +103,14 @@ def submission_property(prop, submission):
         return mark_safe(f'<a href="{replaced_value}">{value}</a>')
     else:
         return replaced_value
+
+@register.filter
+def submission_property(prop, submission):
+    return _as_property(prop, submission.info.get(prop.name, None))
+
+@register.filter
+def reference_property(prop, reference_set):
+    return _as_property(prop, reference_set.property_values.get(prop.name, None))
 
 @register.filter
 def as_bootstrap_field(field):

--- a/dtf/urls.py
+++ b/dtf/urls.py
@@ -21,6 +21,9 @@ urlpatterns = [
     path('<str:project_slug>/submissions', views.view_project_submissions, name='project_submissions'),
     path('<str:project_slug>/submissions/<int:submission_id>', views.view_submission_details, name='submission_details'),
     path('<str:project_slug>/tests/<int:test_id>', views.view_test_result_details, name='test_result_details'),
+    path('<str:project_slug>/reference_sets', views.view_project_reference_sets, name='project_reference_sets'),
+    path('<str:project_slug>/reference_sets/<int:reference_id>', views.view_reference_set_details, name='reference_set_details'),
+    path('<str:project_slug>/test_references/<int:test_id>', views.view_test_reference_details, name='test_reference_details'),
 
     path('api/projects', api.ProjectList.as_view(), name='api_projects'),
     path('api/projects/<str:id>', api.ProjectDetail.as_view(), name='api_project'),

--- a/dtf/urls.py
+++ b/dtf/urls.py
@@ -15,9 +15,10 @@ urlpatterns = [
     path('', RedirectView.as_view(pattern_name='projects', permanent=False)),
     path('projects/', views.view_projects, name='projects'),
     path('projects/new', views.view_new_project, name='new_project'),
-    path('<str:project_slug>', views.view_project_details, name='project_details'),
+    path('<str:project_slug>', RedirectView.as_view(pattern_name='project_submissions', permanent=False), name='project_details'),
     path('<str:project_slug>/settings', views.view_project_settings, name='project_settings'),
     path('<str:project_slug>/webhook/<int:webhook_id>/log', views.view_webhook_log, name='webhook_log'),
+    path('<str:project_slug>/submissions', views.view_project_submissions, name='project_submissions'),
     path('<str:project_slug>/submissions/<int:submission_id>', views.view_submission_details, name='submission_details'),
     path('<str:project_slug>/tests/<int:test_id>', views.view_test_result_details, name='test_result_details'),
 

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -116,7 +116,7 @@ def view_webhook_log(request, project_slug, webhook_id):
         'webhook': webhook,
     })
 
-def view_project_details(request, project_slug):
+def view_project_submissions(request, project_slug):
     project = get_object_or_404(Project, slug=project_slug)
     properties = ProjectSubmissionProperty.objects.filter(project=project)
 
@@ -125,7 +125,7 @@ def view_project_details(request, project_slug):
     page_number = request.GET.get('page')
     submissions = paginator.get_page(page_number)
 
-    return render(request, 'dtf/project_details.html', {
+    return render(request, 'dtf/project_submissions.html', {
         'project':project,
         'properties':properties,
         'submissions':submissions

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -183,3 +183,38 @@ def view_submission_details(request, project_slug, submission_id):
     return render(request, 'dtf/submission_details.html', {
         'submission':submission
     })
+
+def view_project_reference_sets(request, project_slug):
+    project = get_object_or_404(Project, slug=project_slug)
+    properties = ProjectSubmissionProperty.objects.filter(project=project)
+
+    paginator = Paginator(project.reference_sets.order_by('-pk'), per_page=20)
+
+    page_number = request.GET.get('page')
+    reference_sets = paginator.get_page(page_number)
+
+    return render(request, 'dtf/project_reference_sets.html', {
+        'project':project,
+        'properties':properties,
+        'reference_sets':reference_sets
+    })
+
+def view_reference_set_details(request, project_slug, reference_id):
+    project = get_object_or_404(Project, slug=project_slug)
+    reference_set = get_object_or_404(ReferenceSet, pk=reference_id)
+    if reference_set.project != project:
+        raise Http404("The reference set does not belong to this project")
+    return render(request, 'dtf/reference_set_details.html', {
+        'reference_set': reference_set
+    })
+
+def view_test_reference_details(request, project_slug, test_id):
+    project = get_object_or_404(Project, slug=project_slug)
+    test_reference = get_object_or_404(TestReference, pk=test_id)
+    reference_set = test_reference.reference_set
+    if reference_set.project != project:
+        raise Http404("The test does not belong to this project")
+
+    return render(request, 'dtf/test_reference_details.html', {
+        'test_reference': test_reference
+    })


### PR DESCRIPTION
The reference sets of a project can now be viewed at the URL
```
example.dtf.com/my-project/reference_sets
```
The page for submissions has been moved to
```
example.dtf.com/my-project/submissions
```
while currently
```
example.dtf.com/my-project
```
will simply redirect to the submissions page (since this resembles the old behavior).

The reference sets page is not yet reachable trough any link or similar. To get to the page one has to enter the URL manually.