### PR TITLE
Add support to create unique submissions

### DIFF
--- a/dtf/api.py
+++ b/dtf/api.py
@@ -113,10 +113,11 @@ class ProjectSubmissionList(generics.ListCreateAPIView):
 
     def get_queryset(self):
         project = get_project_or_404(self.kwargs['project_id'])
-        return project.submissions.order_by('-pk')
+        return project.submissions.filter(**self.request.query_params.dict()).order_by('-pk')
 
     def create(self, request, *args, **kwargs):
-        request.data['project'] = get_project_or_404(self.kwargs['project_id']).id
+        project = get_project_or_404(self.kwargs['project_id'])
+        request.data['project'] = project.id
         unique_key = request.query_params.get('unique_key')
         info = request.data.get('info')
         if unique_key is not None and info is not None and unique_key in info:
@@ -126,7 +127,7 @@ class ProjectSubmissionList(generics.ListCreateAPIView):
 
             with transaction.atomic():
                 try:
-                    submission = self.get_queryset().get(**query)
+                    submission = project.submissions.get(**query)
                     return Response("Submission for the unique key does already exist", status.HTTP_409_CONFLICT)
                 except ObjectDoesNotExist:
                     return super().create(request, *args, **kwargs)

--- a/dtf/api.py
+++ b/dtf/api.py
@@ -3,6 +3,7 @@ from django.db import IntegrityError
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import transaction
 
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
@@ -116,6 +117,20 @@ class ProjectSubmissionList(generics.ListCreateAPIView):
 
     def create(self, request, *args, **kwargs):
         request.data['project'] = get_project_or_404(self.kwargs['project_id']).id
+        unique_key = request.query_params.get('unique_key')
+        info = request.data.get('info')
+        if unique_key is not None and info is not None and unique_key in info:
+            query = {
+                f'info__{unique_key}': info[unique_key]
+            }
+
+            with transaction.atomic():
+                try:
+                    submission = self.get_queryset().get(**query)
+                    return Response("Submission for the unique key does already exist", status.HTTP_409_CONFLICT)
+                except ObjectDoesNotExist:
+                    return super().create(request, *args, **kwargs)
+
         return super().create(request, *args, **kwargs)
 
 class ProjectSubmissionDetail(generics.RetrieveUpdateDestroyAPIView):

--- a/dtf/tests/test_api.py
+++ b/dtf/tests/test_api.py
@@ -771,7 +771,7 @@ class ReferenceSetsApiTest(ApiTestCase):
 
         # Filter for 'Property 1' only:
         # we should get two results
-        response = client.get(self.url_2 + "?Property 1=Value 1")
+        response = client.get(self.url_2, {"Property 1" : "Value 1"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
         self.assertEqual(response.data[0], serializer_2.data)
@@ -779,20 +779,20 @@ class ReferenceSetsApiTest(ApiTestCase):
 
         # Filter for 'Property 1' and 'Property 2':
         # we should get a single result
-        response = client.get(self.url_2 + "?Property 1=Value 1&Property 2=Value 2")
+        response = client.get(self.url_2, {"Property 1" : "Value 1", "Property 2" : "Value 2"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0], serializer_2.data)
 
         # Filter for 'Property 1' and 'Property 2':
         # we should get no results
-        response = client.get(self.url_2 + "?Property 1=Value 1&Property 2=Value 3")
+        response = client.get(self.url_2, {"Property 1" : "Value 1", "Property 2" : "Value 3"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 0)
 
         # Filter for 'Property 1' and 'Property 3':
         # Since Property 3 does not influence the reference, we still get two results
-        response = client.get(self.url_2 + "?Property 1=Value 1&Property 3=Value 2")
+        response = client.get(self.url_2, {"Property 1" : "Value 1", "Property 3" : "Value 2"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
         self.assertEqual(response.data[0], serializer_2.data)
@@ -993,19 +993,19 @@ class TestReferencesApiTest(ApiTestCase):
         self.post(self.url, {'test_name' : "Test 1", 'default_source' : self.test_1_1_id, 'references' : {'Result1' : {'value' : 2}}})
         self.post(self.url, {'test_name' : "Test 2", 'default_source' : self.test_2_1_id, 'references' : {'Result1' : {'value' : 2}, 'Result2' : {'value' : { 'data' : 3.0, 'type' : 'float'}}}})
 
-        response = client.get(self.url + "?test_name=Test%201")
+        response = client.get(self.url, {"test_name" : "Test 1"})
         test_references = self.reference_set_1.test_references.filter(test_name='Test 1').order_by('-pk')
         serializer = TestReferenceSerializer(test_references, many=True)
         self.assertEqual(response.data, serializer.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        response = client.get(self.url + "?test_name=Test%202")
+        response = client.get(self.url, {"test_name" : "Test 2"})
         test_references = self.reference_set_1.test_references.filter(test_name='Test 2').order_by('-pk')
         serializer = TestReferenceSerializer(test_references, many=True)
         self.assertEqual(response.data, serializer.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
-        response = client.get(self.url + "?test_name=DoesNotExit")
+        response = client.get(self.url, {"test_name" : "DoesNotExit"})
         self.assertEqual(response.data, [])
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 


### PR DESCRIPTION
This MR adds support to add a `unique_key` query parameter to the submission POST request like this:

```
curl --header "Content-Type: application/json" \
     --data '{"info" : {"Branch" : "develop", "Hostname" : "Vasa"}}' \
     dtf.example.com/api/projects/my-project/submissions?unique_key=Hostname
```

This will only create a new submission, if there is no submission with a `Hostname=Vasa` info entry already. If a submission with such an entry does already exist, it will return a 409 (conflict) response.

Additionally it is now possible to use query strings in a GET request to the submissions endpoint. E.g.

```
curl dtf.example.com/api/projects/my-project/submissions?info__Hostname=Vasa
```

to get all submissions from the `Vasa` host.