### PR TITLE
Webhook improvements

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -125,5 +125,8 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
 # when no user is logged in.
 DTF_DEFAULT_DISPLAY_TIME_ZONE = "UTC"
 
+# Whether to enable triggering webhooks on model changes.
+DTF_ENABLE_WEBHOOKS = True
+
 # Whether to use a thread pool to handle webhooks.
 DTF_WEBHOOK_THREADPOOL = False

--- a/settings/development.py
+++ b/settings/development.py
@@ -1,9 +1,12 @@
+import os
 
 from .common import *
 
 DEBUG = True
 
 ALLOWED_HOSTS = ['*']
+
+DTF_ENABLE_WEBHOOKS = (os.environ.get("DTF_ENABLE_WEBHOOKS", "1") == "1")
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases


### PR DESCRIPTION
This improves some aspects of webhooks:

 - We disable webhooks during migrations. Migrations might trigger a lot of webhooks, which might slow down the migration process drastically. Additionally since the DB is in a non-consistent state during the migration process, it could lead to errors if the webhooks try to access the DB.
 - We add an option to the settings, to disable webhooks completely for an instance. For the development settings, this can be controlled via the environment variable `DTF_ENABLE_WEBHOOKS`.
 - Fix webhooks when operating on the non-default database. From now on the webhook log entry will be added to the same database as the object that triggered the webhook comes from.