### PR TITLE
Add script to setup a demo database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ env/
 
 # Django specific
 db.sqlite3
+demo-db.sqlite3
 
 settings/local.py
 

--- a/dtf/fixtures/demo-project.json
+++ b/dtf/fixtures/demo-project.json
@@ -1,0 +1,65 @@
+[
+    {
+        "model": "dtf.project",
+        "pk": 1,
+        "fields": {
+            "name": "Demo Project",
+            "slug": "demo",
+            "created": "2021-04-06T07:21:22.515Z",
+            "last_updated": "2021-04-06T07:21:22.515Z"
+        }
+    },
+    {
+        "model": "dtf.projectsubmissionproperty",
+        "pk": 1,
+        "fields": {
+            "project": 1,
+            "name": "Branch",
+            "required": true,
+            "display": true,
+            "display_replace": "",
+            "display_as_link": false,
+            "influence_reference": true
+        }
+    },
+    {
+        "model": "dtf.projectsubmissionproperty",
+        "pk": 2,
+        "fields": {
+            "project": 1,
+            "name": "Hostname",
+            "required": true,
+            "display": true,
+            "display_replace": "",
+            "display_as_link": false,
+            "influence_reference": true
+        }
+    },
+    {
+        "model": "dtf.projectsubmissionproperty",
+        "pk": 3,
+        "fields": {
+            "project": 1,
+            "name": "GitLab CI Job",
+            "required": false,
+            "display": true,
+            "display_replace": "https://gitlab.example.com/demo/demo-project/-/jobs/{VALUE}",
+            "display_as_link": true,
+            "influence_reference": false
+        }
+    },
+    {
+        "model": "dtf.webhook",
+        "pk": 1,
+        "fields": {
+            "project": 1,
+            "name": "Demo Bot",
+            "url": "http://129.26.133.164:8666/references/demo",
+            "secret_token": "58a61681-f3c0-4d0f-a8bf-c87193f2603d",
+            "on_submission": false,
+            "on_test_result": false,
+            "on_reference_set": false,
+            "on_test_reference": true
+        }
+    }
+]

--- a/dtf/fixtures/demo-submissions.json
+++ b/dtf/fixtures/demo-submissions.json
@@ -1,0 +1,282 @@
+[
+    {
+        "model": "dtf.submission",
+        "pk": 1,
+        "fields": {
+            "project": 1,
+            "created": "2021-04-06T08:02:57.168Z",
+            "last_updated": "2021-04-06T08:02:57.169Z",
+            "info": {
+                "Hostname": "Vasa",
+                "Branch": "main"
+            }
+        }
+    },
+    {
+        "model": "dtf.submission",
+        "pk": 2,
+        "fields": {
+            "project": 1,
+            "created": "2021-04-06T08:10:24.740Z",
+            "last_updated": "2021-04-06T08:10:24.740Z",
+            "info": {
+                "Hostname": "Vasa",
+                "Branch": "main"
+            }
+        }
+    },
+    {
+        "model": "dtf.testresult",
+        "pk": 1,
+        "fields": {
+            "name": "demo (np=1)",
+            "submission": 1,
+            "created": "2021-04-06T08:02:57.249Z",
+            "last_updated": "2021-04-06T08:02:57.249Z",
+            "results": [
+                {
+                    "name": "runtime",
+                    "value": {
+                        "data": "PT0.124356S",
+                        "type": "duration"
+                    },
+                    "status": "unknown",
+                    "reference": null
+                },
+                {
+                    "name": "residual[0]",
+                    "value": {
+                        "data": 2.345,
+                        "type": "float"
+                    },
+                    "status": "unknown",
+                    "reference": null
+                },
+                {
+                    "name": "integer[0]",
+                    "value": {
+                        "data": 98,
+                        "type": "integer"
+                    },
+                    "status": "unknown",
+                    "reference": null
+                },
+                {
+                    "name": "algorithm-time[0]",
+                    "value": {
+                        "data": "PT0.345000S",
+                        "type": "duration"
+                    },
+                    "status": "unknown",
+                    "reference": null
+                },
+                {
+                    "name": "argument[0]",
+                    "value": {
+                        "data": "process argument 1",
+                        "type": "string"
+                    },
+                    "status": "unknown",
+                    "reference": null
+                },
+                {
+                    "name": "argument[1]",
+                    "value": {
+                        "data": "process argument 2",
+                        "type": "string"
+                    },
+                    "status": "unknown",
+                    "reference": null
+                },
+                {
+                    "name": "screenshot-image.png",
+                    "value": {
+                        "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                        "type": "image"
+                    },
+                    "status": "unknown",
+                    "reference": null
+                }
+            ],
+            "status": "unknown"
+        }
+    },
+    {
+        "model": "dtf.testresult",
+        "pk": 2,
+        "fields": {
+            "name": "demo (np=1)",
+            "submission": 2,
+            "created": "2021-04-06T08:10:24.818Z",
+            "last_updated": "2021-04-06T08:10:24.818Z",
+            "results": [
+                {
+                    "name": "runtime",
+                    "value": {
+                        "data": "PT0.094780S",
+                        "type": "duration"
+                    },
+                    "reference": {
+                        "data": "PT0.124356S",
+                        "type": "duration"
+                    },
+                    "reference_source": 1,
+                    "status": "successful"
+                },
+                {
+                    "name": "residual[0]",
+                    "value": {
+                        "data": 2.345,
+                        "type": "float"
+                    },
+                    "reference": {
+                        "data": 2.345,
+                        "type": "float"
+                    },
+                    "reference_source": 1,
+                    "status": "successful"
+                },
+                {
+                    "name": "integer[0]",
+                    "value": {
+                        "data": 103,
+                        "type": "integer"
+                    },
+                    "reference": {
+                        "data": 98,
+                        "type": "integer"
+                    },
+                    "reference_source": 1,
+                    "status": "failed"
+                },
+                {
+                    "name": "algorithm-time[0]",
+                    "value": {
+                        "data": "PT0.345000S",
+                        "type": "duration"
+                    },
+                    "reference": {
+                        "data": "PT0.345000S",
+                        "type": "duration"
+                    },
+                    "reference_source": 1,
+                    "status": "successful"
+                },
+                {
+                    "name": "argument[0]",
+                    "value": {
+                        "data": "process argument 1",
+                        "type": "string"
+                    },
+                    "reference": {
+                        "data": "process argument 1",
+                        "type": "string"
+                    },
+                    "reference_source": 1,
+                    "status": "successful"
+                },
+                {
+                    "name": "argument[1]",
+                    "value": {
+                        "data": "process argument 2",
+                        "type": "string"
+                    },
+                    "reference": {
+                        "data": "process argument 2",
+                        "type": "string"
+                    },
+                    "reference_source": 1,
+                    "status": "successful"
+                },
+                {
+                    "name": "screenshot-image.png",
+                    "value": {
+                        "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                        "type": "image"
+                    },
+                    "reference": {
+                        "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                        "type": "image"
+                    },
+                    "reference_source": 1,
+                    "status": "successful"
+                }
+            ],
+            "status": "failed"
+        }
+    },
+    {
+        "model": "dtf.referenceset",
+        "pk": 1,
+        "fields": {
+            "project": 1,
+            "created": "2021-04-06T08:03:29.011Z",
+            "last_updated": "2021-04-06T08:03:29.011Z",
+            "property_values": {
+                "Branch": "main",
+                "Hostname": "Vasa"
+            }
+        }
+    },
+    {
+        "model": "dtf.testreference",
+        "pk": 1,
+        "fields": {
+            "reference_set": 1,
+            "test_name": "demo (np=1)",
+            "created": "2021-04-06T08:03:29.072Z",
+            "last_updated": "2021-04-06T08:03:29.072Z",
+            "references": {
+                "runtime": {
+                    "value": {
+                        "data": "PT0.124356S",
+                        "type": "duration"
+                    },
+                    "source": 1
+                },
+                "residual[0]": {
+                    "value": {
+                        "data": 2.345,
+                        "type": "float"
+                    },
+                    "source": 1
+                },
+                "integer[0]": {
+                    "value": {
+                        "data": 98,
+                        "type": "integer"
+                    },
+                    "source": 1
+                },
+                "algorithm-time[0]": {
+                    "value": {
+                        "data": "PT0.345000S",
+                        "type": "duration"
+                    },
+                    "source": 1
+                },
+                "argument[0]": {
+                    "value": {
+                        "data": "process argument 1",
+                        "type": "string"
+                    },
+                    "source": 1
+                },
+                "argument[1]": {
+                    "value": {
+                        "data": "process argument 2",
+                        "type": "string"
+                    },
+                    "source": 1
+                },
+                "screenshot-image.png": {
+                    "value": {
+                        "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                        "type": "image"
+                    },
+                    "source": 1
+                }
+            }
+        }
+    }
+]

--- a/dtf/fixtures/demo-user.json
+++ b/dtf/fixtures/demo-user.json
@@ -1,0 +1,20 @@
+[
+    {
+        "model": "auth.user",
+        "pk": 1,
+        "fields": {
+            "password": "pbkdf2_sha256$216000$RXLBrHkNPhaJ$oo7jE0jK5rNCLUwFAZ4ShcQAMqNL6oPPxSLz/VUDr68=",
+            "last_login": null,
+            "is_superuser": true,
+            "username": "root",
+            "first_name": "",
+            "last_name": "",
+            "email": "root@example.com",
+            "is_staff": true,
+            "is_active": true,
+            "date_joined": "2021-04-06T07:16:08.047Z",
+            "groups": [],
+            "user_permissions": []
+        }
+    }
+]

--- a/dtf/fixtures/demo-webhook-log.json
+++ b/dtf/fixtures/demo-webhook-log.json
@@ -1,0 +1,90 @@
+[
+    {
+        "model": "dtf.webhooklogentry",
+        "pk": 1,
+        "fields": {
+            "webhook": 1,
+            "created": "2021-04-06T08:03:31.281Z",
+            "trigger": "TestReference",
+            "request_url": "http://129.26.133.164:8666/references/demo",
+            "request_data": {
+                "event": "create",
+                "source": "testreference",
+                "project": {
+                    "id": 1,
+                    "name": "Demo Project",
+                    "slug": "demo",
+                    "created": "2021-04-06T07:21:22.515000Z",
+                    "last_updated": "2021-04-06T07:21:22.515000Z",
+                    "url": "/demo"
+                },
+                "object": {
+                    "reference_set": 1,
+                    "test_name": "demo (np=1)",
+                    "id": 1,
+                    "created": "2021-04-06T08:03:29.072778Z",
+                    "last_updated": "2021-04-06T08:03:29.072778Z",
+                    "references": {
+                        "runtime": {
+                            "value": {
+                                "data": "PT0.124356S",
+                                "type": "duration"
+                            },
+                            "source": 1
+                        },
+                        "residual[0]": {
+                            "value": {
+                                "data": 2.345,
+                                "type": "float"
+                            },
+                            "source": 1
+                        },
+                        "integer[0]": {
+                            "value": {
+                                "data": 98,
+                                "type": "integer"
+                            },
+                            "source": 1
+                        },
+                        "algorithm-time[0]": {
+                            "value": {
+                                "data": "PT0.345000S",
+                                "type": "duration"
+                            },
+                            "source": 1
+                        },
+                        "argument[0]": {
+                            "value": {
+                                "data": "process argument 1",
+                                "type": "string"
+                            },
+                            "source": 1
+                        },
+                        "argument[1]": {
+                            "value": {
+                                "data": "process argument 2",
+                                "type": "string"
+                            },
+                            "source": 1
+                        },
+                        "screenshot-image.png": {
+                            "value": {
+                                "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                                "type": "image"
+                            },
+                            "source": 1
+                        }
+                    }
+                }
+            },
+            "request_headers": {
+                "X-DTF-Token": "58a61681-f3c0-4d0f-a8bf-c87193f2603d",
+                "Content-Length": "2346",
+                "Content-Type": "application/json"
+            },
+            "response_status": 0,
+            "response_data": "HTTPConnectionPool(host='129.26.133.164', port=8666): Max retries exceeded with url: /references/demo (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x00000221DFD1E5E0>: Failed to establish a new connection: [WinError 10061] No connection could be made because the target machine actively refused it'))",
+            "response_headers": {}
+        }
+    }
+]

--- a/dtf/migrations/0007_addprojectslug.py
+++ b/dtf/migrations/0007_addprojectslug.py
@@ -4,8 +4,9 @@ from django.db import migrations, models
 from django.utils.text import slugify
 
 def generate_default_project_slugs(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
     Project = apps.get_model('dtf', 'Project')
-    for project in Project.objects.all().iterator():
+    for project in Project.objects.using(db_alias).all().iterator():
         project.slug = slugify(project.name)
         project.save()
 

--- a/dtf/migrations/0016_require_related_fields.py
+++ b/dtf/migrations/0016_require_related_fields.py
@@ -4,11 +4,12 @@ from django.db import migrations, models
 import django.db.models.deletion
 
 def delete_unrelated_objects(apps, schema_editor):
-    apps.get_model('dtf', 'ProjectSubmissionProperty').objects.filter(project=None).delete()
-    apps.get_model('dtf', 'ReferenceSet').objects.filter(project=None).delete()
-    apps.get_model('dtf', 'Submission').objects.filter(project=None).delete()
-    apps.get_model('dtf', 'TestReference').objects.filter(reference_set=None).delete()
-    apps.get_model('dtf', 'TestResult').objects.filter(submission=None).delete()
+    db_alias = schema_editor.connection.alias
+    apps.get_model('dtf', 'ProjectSubmissionProperty').objects.using(db_alias).filter(project=None).delete()
+    apps.get_model('dtf', 'ReferenceSet').objects.using(db_alias).filter(project=None).delete()
+    apps.get_model('dtf', 'Submission').objects.using(db_alias).filter(project=None).delete()
+    apps.get_model('dtf', 'TestReference').objects.using(db_alias).filter(reference_set=None).delete()
+    apps.get_model('dtf', 'TestResult').objects.using(db_alias).filter(submission=None).delete()
 
 
 class Migration(migrations.Migration):

--- a/dtf/migrations/0018_update_test_json_structure.py
+++ b/dtf/migrations/0018_update_test_json_structure.py
@@ -37,6 +37,7 @@ def convert_to_valuetype(data, valuetype):
     return data
 
 def upgrade_test_results(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
     TestResult = apps.get_model('dtf', 'TestResult')
 
     def upgrade_results(test_results):
@@ -80,12 +81,13 @@ def upgrade_test_results(apps, schema_editor):
             })
         return new_test_results
 
-    for test_result in progressbar(TestResult.objects.all().iterator()):
+    for test_result in progressbar(TestResult.objects.using(db_alias).all().iterator()):
         test_result.results = upgrade_results(test_result.results)
         test_result.save()
 
 
 def upgrade_test_references(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
     TestReference = apps.get_model('dtf', 'TestReference')
 
     def upgrade_references(references):
@@ -103,7 +105,7 @@ def upgrade_test_references(apps, schema_editor):
             new_references[name] = new_reference
         return new_references
 
-    for test_reference in progressbar(TestReference.objects.all().iterator()):
+    for test_reference in progressbar(TestReference.objects.using(db_alias).all().iterator()):
         test_reference.references = upgrade_references(test_reference.references)
         test_reference.save()
 

--- a/settings/development.py
+++ b/settings/development.py
@@ -11,8 +11,15 @@ DTF_ENABLE_WEBHOOKS = (os.environ.get("DTF_ENABLE_WEBHOOKS", "1") == "1")
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
 DATABASES = {
-    'default': {
+    'main': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    },
+    'demo': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'demo-db.sqlite3'),
     }
 }
+
+default_database = os.environ.get('DTF_DEFAULT_DATABASE', 'main')
+DATABASES['default'] = DATABASES[default_database]

--- a/setup-demo-db.py
+++ b/setup-demo-db.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--force', action='store_true',
+                    help='Do not ask for permission to delete an existing database. Just delete it.')
+args = parser.parse_args()
+
+root_path = os.path.dirname(os.path.realpath(__file__))
+
+manage_script_path = os.path.join(root_path, "manage.py")
+
+db_path = os.path.join(root_path, "db.sqlite3")
+
+if os.path.exists(db_path):
+    print("WARNING: found existing database at:")
+    print("  {}".format(db_path))
+
+    if args.force:
+        print("Deleting file due to --force being used.")
+    else:
+        print("Procceding will delete all data in that file.")
+        print("Are you sure you want to continue? [Y/n]")
+        answer = sys.stdin.read(1)
+        if answer != 'Y' and answer != 'y':
+            exit(0)
+
+    os.remove(db_path)
+
+os.system(f"{sys.executable} {manage_script_path} migrate")
+os.system(f"{sys.executable} {manage_script_path} loaddata demo-user") # Name: root PW: test1234
+os.system(f"{sys.executable} {manage_script_path} loaddata demo-project")
+os.system(f"{sys.executable} {manage_script_path} loaddata demo-submissions")
+os.system(f"{sys.executable} {manage_script_path} loaddata demo-webhook-log")

--- a/setup-demo-db.py
+++ b/setup-demo-db.py
@@ -11,7 +11,7 @@ root_path = os.path.dirname(os.path.realpath(__file__))
 
 manage_script_path = os.path.join(root_path, "manage.py")
 
-db_path = os.path.join(root_path, "db.sqlite3")
+db_path = os.path.join(root_path, "demo-db.sqlite3")
 
 if os.path.exists(db_path):
     print("WARNING: found existing database at:")
@@ -28,8 +28,8 @@ if os.path.exists(db_path):
 
     os.remove(db_path)
 
-os.system(f"{sys.executable} {manage_script_path} migrate")
-os.system(f"{sys.executable} {manage_script_path} loaddata demo-user") # Name: root PW: test1234
-os.system(f"{sys.executable} {manage_script_path} loaddata demo-project")
-os.system(f"{sys.executable} {manage_script_path} loaddata demo-submissions")
-os.system(f"{sys.executable} {manage_script_path} loaddata demo-webhook-log")
+os.system(f"{sys.executable} {manage_script_path} migrate --database demo")
+os.system(f"{sys.executable} {manage_script_path} loaddata --database demo demo-user") # Name: root PW: test1234
+os.system(f"{sys.executable} {manage_script_path} loaddata --database demo demo-project")
+os.system(f"{sys.executable} {manage_script_path} loaddata --database demo demo-submissions")
+os.system(f"{sys.executable} {manage_script_path} loaddata --database demo demo-webhook-log")


### PR DESCRIPTION
This MR adds a script `setup-demo-db.py` that can be used to initialize a database with some data (projects, submissions, references, ...) for demonstration purposes.
The demo database is added as new database entry in the settings under the name `demo`. One should set the environment variable `DTF_DEFAULT_DATABASE=demo` before running `python manage.py runserver` to make sure the correct database gets picked up.