### PR TITLE
Save filter state

### DIFF
--- a/dtf/static/dtf/script.js
+++ b/dtf/static/dtf/script.js
@@ -1,21 +1,4 @@
 $(document).ready(function() {
-
-    $("input[name='filter_status']").change(function () {
-        var status_type = this.value;
-        var checked = this.checked;
-        $('table > tbody > tr > td > span').each(function(index, elem) {
-            if (elem.textContent.trim() != status_type){
-                return;
-            }
-            if (checked) {
-                elem.parentElement.parentElement.style.display = "table-row";
-            }
-            else {
-                elem.parentElement.parentElement.style.display = "none";
-            }
-        });
-    });
-
     $(".tablesorter").tablesorter();
 });
     

--- a/dtf/templates/dtf/filter-box.html
+++ b/dtf/templates/dtf/filter-box.html
@@ -37,19 +37,59 @@
 </div>
 
 <script>
+function restoreFilterState(status_type, filter_status) {
+    const filterState = (sessionStorage.getItem("filter-{{filter_context}}-" + status_type) || 'true') === 'true';
+
+    const checkBox = document.getElementById("filter_" + status_type);
+    if(checkBox) {
+        checkBox.checked = filterState;
+    }
+    return filterState;
+}
+
+$('document').ready(function(){
+if(sessionStorage) {
+    var filter_status = {};
+    filter_status["successful"] = restoreFilterState("successful");
+    filter_status["unstable"] = restoreFilterState("unstable", filter_status);
+    filter_status["failed"] = restoreFilterState("failed", filter_status);
+    filter_status["skip"] = restoreFilterState("skip", filter_status);
+    filter_status["broken"] = restoreFilterState("broken", filter_status);
+    filter_status["unknown"] = restoreFilterState("unknown", filter_status);
+
+    const rows = document.getElementsByClassName("filtered-row");
+    Array.prototype.forEach.call(rows, function(item){
+        const row_status_type = item.getElementsByClassName("filter-status")[0].textContent.trim();
+        const checked = filter_status[row_status_type]
+        if (checked) {
+            item.style.display = "table-row";
+        }
+        else {
+            item.style.display = "none";
+        }
+    });
+}
+});
+
 $("input[name='filter_status']").change(function () {
     var status_type = this.value;
     var checked = this.checked;
-    $('table > tbody > tr > td > span').each(function(index, elem) {
-        if (elem.textContent.trim() != status_type){
+
+    const rows = document.getElementsByClassName("filtered-row");
+    Array.prototype.forEach.call(rows, function(item){
+        const row_status_type = item.getElementsByClassName("filter-status")[0].textContent.trim();
+        if (row_status_type != status_type){
             return;
         }
         if (checked) {
-            elem.parentElement.parentElement.style.display = "table-row";
+            item.style.display = "table-row";
         }
         else {
-            elem.parentElement.parentElement.style.display = "none";
+            item.style.display = "none";
         }
     });
+    if(sessionStorage) {
+        sessionStorage.setItem("filter-{{filter_context}}-" + status_type, checked);
+    }
 });
 </script>

--- a/dtf/templates/dtf/filter-box.html
+++ b/dtf/templates/dtf/filter-box.html
@@ -35,3 +35,21 @@
     </div>
 
 </div>
+
+<script>
+$("input[name='filter_status']").change(function () {
+    var status_type = this.value;
+    var checked = this.checked;
+    $('table > tbody > tr > td > span').each(function(index, elem) {
+        if (elem.textContent.trim() != status_type){
+            return;
+        }
+        if (checked) {
+            elem.parentElement.parentElement.style.display = "table-row";
+        }
+        else {
+            elem.parentElement.parentElement.style.display = "none";
+        }
+    });
+});
+</script>

--- a/dtf/templates/dtf/submission_details.html
+++ b/dtf/templates/dtf/submission_details.html
@@ -27,7 +27,7 @@
 </div>
 
 <div class="pt-3 pb-1">
-    {% include 'dtf/filter-box.html' with show_broken=True %}
+    {% include 'dtf/filter-box.html' with show_broken=True filter_context=submission%}
     <div class="float-right content-sidebar-dependent">
         <button class="btn btn-outline-dark btn-sm" onclick="toggleContentSidebar()"><i class="bi bi-chevron-double-left"></i></button>
     </div>
@@ -49,8 +49,8 @@
     </thead>
     <tbody>
     {% for test in submission.tests.all %}
-    <tr class="test">
-        <td class="status">
+    <tr class="filtered-row test">
+        <td class="filter-status status">
             <a href="{% url 'test_result_details' submission.project.slug test.pk %}">{{ test.status|status_badge }}</a>
         </td>
         <td class="name">

--- a/dtf/templates/dtf/test_result_details.html
+++ b/dtf/templates/dtf/test_result_details.html
@@ -167,7 +167,7 @@ function toggleAllBoxes(){
 </div>
 
 <div class="mt-3 pb-1">
-    {% include 'dtf/filter-box.html' with show_broken=False %}
+    {% include 'dtf/filter-box.html' with show_broken=False filter_context=test %}
     <div class="float-right content-sidebar-dependent">
         <button class="btn btn-outline-dark btn-sm" onclick="toggleContentSidebar()"><i class="bi bi-chevron-double-left"></i></button>
     </div>
@@ -200,8 +200,8 @@ function toggleAllBoxes(){
     </thead>
     <tbody>
     {% for parameter in data %}
-        <tr>
-            <td>
+        <tr class="filtered-row">
+            <td class="filter-status">
                 {{ parameter.status|status_badge }}
             </td>
             <td>


### PR DESCRIPTION
This MR saves the checked filters on the submission and test details pages. To save the states the browsers "sessionStorage" is used, which means the saved filters will be remembered as long as the browser session is alive (e.g. closing and restarting the browser will reset all filters to default).

Closes #35 