### PR TITLE
Introduce initial user support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,14 +13,6 @@ Welcome to the Django Testing Framework documentation
    modules/quickstart
    modules/api
 
-.. toctree::
-   :maxdepth: 3
-   :caption: Code docstrings
-
-   modules/models
-   modules/views
-   modules/serializer
-
 
 Indices and tables
 ==================

--- a/docs/modules/api.rst
+++ b/docs/modules/api.rst
@@ -32,6 +32,8 @@ API Overview
 
 :doc:`References <api/references>`
 
+:doc:`Users <api/users>`
+
 .. toctree::
    :hidden:
 
@@ -39,3 +41,4 @@ API Overview
    api/submissions
    api/test_results
    api/references
+   api/users

--- a/docs/modules/api.rst
+++ b/docs/modules/api.rst
@@ -18,8 +18,43 @@ Some API endpoints include parameters of the form ``:id``. These are to be repla
 
     curl "http://dtf.example.com/api/projects/4"
 
-.. Authentication
-.. --------------
+Authentication
+--------------
+
+To access the API users must authenticate themselves. There are currently two end-user methods for authentication available:
+
+  - :ref:`User credentials <api-authentication-credentials>` (username and password) 
+  - :ref:`User access Token <api-authentication-token>`
+
+.. _api-authentication-credentials:
+
+User credentials
+````````````````
+
+.. note::
+  This method should not be used except for simple testing scenarios.
+
+A user can authenticate themselves with their username and password. E.g. when using `curl` this can be done by using the `-u` command line parameter:
+
+.. code-block:: bash
+
+    curl -u "username:password" \
+      "http://dtf.example.com/api/projects/4"
+
+.. _api-authentication-token:
+
+User access Token
+`````````````````
+
+.. note::
+  There is not yet any front-end functionality for a user to create tokens.
+
+A user can authenticate themselves with a specific token, unique to each user. This token needs to be passed in the *header* of requests. E.g. when using `curl` this can be done by using the `--header` command line parameter:
+
+.. code-block:: bash
+
+    curl --header "Authorization: Token 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b" \
+      "http://dtf.example.com/api/projects/4"
 
 API Overview
 ------------

--- a/docs/modules/api/endpoints/users/users-GET.json
+++ b/docs/modules/api/endpoints/users/users-GET.json
@@ -1,0 +1,7 @@
+{
+    "endpoint": "/users",
+    "method": "GET",
+    "examples" : [
+        {}
+    ]
+}

--- a/docs/modules/api/endpoints/users/users_id-GET.json
+++ b/docs/modules/api/endpoints/users/users_id-GET.json
@@ -1,0 +1,18 @@
+{
+    "endpoint": "/users/:id",
+    "method": "GET",
+    "attributes" : {
+        ":id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the user to get."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "id" : 2
+            }
+        }
+    ]
+}

--- a/docs/modules/api/generated/users/users-GET-curl.sh
+++ b/docs/modules/api/generated/users/users-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/users

--- a/docs/modules/api/generated/users/users-GET-desc.txt
+++ b/docs/modules/api/generated/users/users-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /users

--- a/docs/modules/api/generated/users/users-GET-response.json
+++ b/docs/modules/api/generated/users/users-GET-response.json
@@ -1,0 +1,14 @@
+[
+    {
+        "id": 1,
+        "username": "root",
+        "first_name": "",
+        "last_name": ""
+    },
+    {
+        "id": 2,
+        "username": "demo",
+        "first_name": "Demo",
+        "last_name": "User"
+    }
+]

--- a/docs/modules/api/generated/users/users_id-GET-attributes.csv
+++ b/docs/modules/api/generated/users/users_id-GET-attributes.csv
@@ -1,0 +1,2 @@
+Attribute|Type|Required|Description
+``:id``|integer|yes|The id of the user to get.

--- a/docs/modules/api/generated/users/users_id-GET-curl.sh
+++ b/docs/modules/api/generated/users/users_id-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/users/2

--- a/docs/modules/api/generated/users/users_id-GET-desc.txt
+++ b/docs/modules/api/generated/users/users_id-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /users/:id

--- a/docs/modules/api/generated/users/users_id-GET-response.json
+++ b/docs/modules/api/generated/users/users_id-GET-response.json
@@ -1,0 +1,6 @@
+{
+    "id": 2,
+    "username": "demo",
+    "first_name": "Demo",
+    "last_name": "User"
+}

--- a/docs/modules/api/users.rst
+++ b/docs/modules/api/users.rst
@@ -1,0 +1,47 @@
+Users API
+=========
+
+.. _api-users-list:
+
+List users
+-------------
+
+List all users available on the server.
+
+.. literalinclude :: generated/users/users-GET-desc.txt
+
+An example could look as follows:
+
+
+.. literalinclude :: generated/users/users-GET-curl.sh
+   :language: bash
+
+which might give a result like this:
+
+.. literalinclude :: generated/users/users-GET-response.json
+   :language: json
+
+
+.. _api-users-get:
+
+Get single user
+----------------
+
+Retrieve a specific user from the server.
+
+.. literalinclude :: generated/users/users_id-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/users/users_id-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. literalinclude :: generated/users/users_id-GET-curl.sh
+   :language: bash
+
+which might give a result like this:
+
+.. literalinclude :: generated/users/users_id-GET-response.json
+   :language: json

--- a/docs/modules/models.rst
+++ b/docs/modules/models.rst
@@ -1,4 +1,0 @@
-Models
-======
-.. automodule:: dtf.models
-  :members:

--- a/docs/modules/quickstart.rst
+++ b/docs/modules/quickstart.rst
@@ -43,6 +43,3 @@ By default, the server is only available locally and starts on port 8000. You ca
     python manage.py runserver 0.0.0.0:80
 
 The server is then reachable for all hosts on the network under the default HTTP port 80.
-
-Using the API
--------------

--- a/docs/modules/serializer.rst
+++ b/docs/modules/serializer.rst
@@ -1,4 +1,0 @@
-Serializer
-==========
-.. automodule:: dtf.serializers
-  :members:

--- a/docs/modules/views.rst
+++ b/docs/modules/views.rst
@@ -1,4 +1,0 @@
-Views
-======
-.. automodule:: dtf.views
-  :members:

--- a/docs/regenerate_api_docs.py
+++ b/docs/regenerate_api_docs.py
@@ -92,7 +92,7 @@ def regenerate_docs():
                 file.write(f'  {example_url}')
 
             url =  example_url.replace(example_server_name, localhost_server_name)
-            response = requests.request(method, url, json=data)
+            response = requests.request(method, url, json=data, auth=('root', 'test1234'))
 
             if not response.ok:
                 print(f"FAILED: {method} {url}")

--- a/dtf/api.py
+++ b/dtf/api.py
@@ -7,12 +7,14 @@ from django.shortcuts import get_object_or_404
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.utils.dateparse import parse_duration
+from django.contrib.auth.models import User
 
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework import generics
 
+from dtf.serializers import UserSerializer
 from dtf.serializers import ProjectSerializer
 from dtf.serializers import TestResultSerializer
 from dtf.serializers import ReferenceSetSerializer
@@ -37,6 +39,18 @@ def get_child_or_404(objects, **kwargs):
     except ObjectDoesNotExist:
         raise Http404
     return obj
+
+#
+# User API endpoints
+#
+class UserList(generics.ListAPIView):
+    queryset = User.objects.order_by('pk')
+    serializer_class = UserSerializer
+
+class UserDetail(generics.RetrieveAPIView):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    lookup_url_kwarg = 'id'
 
 #
 # Project API endpoints

--- a/dtf/fixtures/demo-user.json
+++ b/dtf/fixtures/demo-user.json
@@ -16,5 +16,23 @@
             "groups": [],
             "user_permissions": []
         }
+    },
+    {
+        "model": "auth.user",
+        "pk": 2,
+        "fields": {
+            "password": "pbkdf2_sha256$216000$dXBOp5y9BgPd$BkluMylC3aEUyG+VGTIGnFzRAiTSmjD28byfxsjqROg=",
+            "last_login": null,
+            "is_superuser": false,
+            "username": "demo",
+            "first_name": "Demo",
+            "last_name": "User",
+            "email": "demo@example.com",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2021-04-06T07:17:08.047Z",
+            "groups": [],
+            "user_permissions": []
+        }
     }
 ]

--- a/dtf/forms.py
+++ b/dtf/forms.py
@@ -1,6 +1,10 @@
 from django import forms
-from django.forms import TextInput
+from django.forms import TextInput, PasswordInput
 from django.utils.safestring import mark_safe
+from django.contrib.auth.models import User
+from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm, SetPasswordForm
+from django.contrib.auth import password_validation
+from django.core.exceptions import ValidationError
 
 from dtf.models import Project, ProjectSubmissionProperty, Webhook
 
@@ -76,3 +80,66 @@ class WebhookForm(forms.ModelForm):
             'on_reference_set': 'Trigger when a reference set is created, modified or deleted.',
             'on_test_reference': 'Trigger when test references are created, modified or deleted.',
         }
+
+class LoginForm(AuthenticationForm):
+    remember_me = forms.BooleanField(required=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields['username'].widget.attrs['placeholder'] = "Username"
+        self.fields['password'].widget.attrs['placeholder'] = "Password"
+
+class NewUserForm(forms.ModelForm):
+
+    password = forms.CharField(
+        strip=False,
+        widget=PasswordInput(attrs={'placeholder': 'Password', 'autocomplete': 'new-password'}),
+        # help_text=password_validation.password_validators_help_text_html()
+    )
+
+    class Meta:
+        model = User
+        fields = ("first_name","last_name","username","email")
+        widgets = {
+            'first_name': TextInput(attrs={'placeholder': 'First Name'}),
+            'last_name': TextInput(attrs={'placeholder': 'Last Name'}),
+            'username': TextInput(attrs={'placeholder': 'Username'}),
+            'email': TextInput(attrs={'placeholder': 'Email address', 'autocomplete': 'email'}),
+        }
+        help_texts = {
+            'username': None
+        }
+
+    def _post_clean(self):
+        super()._post_clean()
+        password = self.cleaned_data.get('password')
+        if password:
+            try:
+                password_validation.validate_password(password, self.instance)
+            except ValidationError as error:
+                self.add_error('password', error)
+
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        user.set_password(self.cleaned_data["password"])
+        if commit:
+            user.save()
+        return user
+
+class ResetPasswordForm(PasswordResetForm):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields['email'].widget.attrs['placeholder'] = "Email address"
+
+class PasswordSetForm(SetPasswordForm):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields['new_password1'].widget.attrs['placeholder'] = "New password"
+        self.fields['new_password2'].widget.attrs['placeholder'] = "Confirm password"
+        self.fields['new_password1'].help_text = None
+        self.fields['new_password2'].help_text = None

--- a/dtf/serializers.py
+++ b/dtf/serializers.py
@@ -7,6 +7,8 @@ import collections
 
 from rest_framework import serializers
 
+from django.contrib.auth.models import User
+
 from dtf.models import Project, TestResult, ReferenceSet, TestReference, Submission, ProjectSubmissionProperty, Webhook, WebhookLogEntry
 from dtf.functions import fill_result_default_values
 
@@ -18,6 +20,11 @@ def _try_build_absolute_uri(serializer, url):
     if request is not None:
         return request.build_absolute_uri(url)
     return url
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['id', 'username', 'first_name', 'last_name']
 
 class ProjectSerializer(serializers.ModelSerializer):
     url = serializers.SerializerMethodField()

--- a/dtf/static/dtf/style.css
+++ b/dtf/static/dtf/style.css
@@ -178,10 +178,34 @@ td.date a {
     color: #ffffff;
 }
 
-.navbar-collapse {
-    flex: 0 0 auto;
-    border-top: 0;
-    padding: 0;
+.nav {
+    flex-wrap: nowrap;
+}
+
+.navbar-nav {
+    display: flex;
+    flex-direction: row;
+    padding-left: 0;
+    margin-bottom: 0;
+    list-style: none;
+}
+
+.nav li {
+    margin: 0 2px;
+}
+
+.nav li a,
+.nav li span,
+.nav li button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 8px;
+    margin: 4px 2px;
+    font-size: 12px;
+    border-radius: 4px;
+    height: 32px;
+    font-weight: 600;
 }
 
 /*

--- a/dtf/static/dtf/users.css
+++ b/dtf/static/dtf/users.css
@@ -1,0 +1,56 @@
+html,
+body {
+  height: 100%;
+}
+
+body {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-align: center;
+    align-items: center;
+    padding-top: 40px;
+    padding-bottom: 40px;
+    background-color: #f5f5f5;
+}
+
+.user-form,
+.user-info {
+    width: 100%;
+    max-width: 350px;
+    padding: 15px;
+    margin: auto;
+}
+.user-form .form-check {
+    padding-left: 0;
+}
+.user-form .form-control {
+    position: relative;
+    box-sizing: border-box;
+    height: auto;
+    padding: 10px;
+    font-size: 16px;
+}
+.user-form .form-control:focus {
+    z-index: 2;
+}
+.signin-form input[name="username"] {
+    margin-bottom: -1px;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+}
+.signin-form input[type="password"] {
+    margin-bottom: 10px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+
+.reset-confirm-form input[name="new_password1"] {
+    margin-bottom: -1px;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+}
+.reset-confirm-form input[name="new_password2"] {
+    margin-bottom: 10px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}

--- a/dtf/templates/dtf/base.html
+++ b/dtf/templates/dtf/base.html
@@ -21,44 +21,14 @@
         <script src="{% static 'dtf/script.js' %}"></script>
 
         <script src="{% static 'dtf/echarts.min.js' %}"></script>
-    </head>
-    <body>
-        {% block header %}
-            <header class="navbar bg-dark border-bottom border-dark text-white">
-                <div class="container-fluid header-content align-items-center">
-                    <div class="title-container">
-                        <h1 class="title">
-                            <a href="{% url 'home' %}">
-                                <span>DTF</span>
-                            </a>
-                        </h1>
-                        <ul class="list-unstyled navbar-sub-nav">
-                            <li>
-                                <a href="{% url 'projects' %}">
-                                    <span>Projects</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="navbar-collapse collapse">
-                    </div>
-                </div>
-            </header>
+
+        {% block head %}
         {% endblock %}
 
-        <div class="layout-page {% block layout %}{% endblock %}">
-            {% block navigation-sidebar %}
-            {% endblock %}
+    </head>
 
-            <div class="content-wrapper">
-                <div class="container-{% block containertype %}xl{% endblock %}">
-                    <main class="content">
-                        {% block content %}{% endblock %}
-                    </main>
-                </div>
-                {% block content-sidebar %}
-                {% endblock %}
-            </div>
-        </div>
+    {% block body %}
+    <body>
     </body>
+    {% endblock %}
 </html>

--- a/dtf/templates/dtf/bootstrap/field.html
+++ b/dtf/templates/dtf/bootstrap/field.html
@@ -20,7 +20,7 @@
     {{ field|add_bootstrap_class}}
   {% endif %}
 
-  {% if field.widget_type == 'text' %}
+  {% if field.widget_type == 'text' or field.widget_type == 'password' %}
     {% if field.help_text %}
       <small class="form-text text-muted">{{ field.help_text }}</small>
     {% endif %}

--- a/dtf/templates/dtf/page_no_sidebar.html
+++ b/dtf/templates/dtf/page_no_sidebar.html
@@ -1,1 +1,1 @@
-{% extends 'dtf/base.html' %}
+{% extends 'dtf/page_with_header.html' %}

--- a/dtf/templates/dtf/page_with_header.html
+++ b/dtf/templates/dtf/page_with_header.html
@@ -1,0 +1,57 @@
+{% extends 'dtf/base.html' %}
+
+{% block body %}
+<body>
+    {% block header %}
+    <header class="navbar bg-dark border-bottom border-dark text-white">
+        <div class="container-fluid header-content align-items-center">
+            <div class="title-container">
+                <h1 class="title">
+                    <a href="{% url 'home' %}">
+                        <span>DTF</span>
+                    </a>
+                </h1>
+                <ul class="list-unstyled navbar-sub-nav">
+                    <li>
+                        <a href="{% url 'projects' %}">
+                            <span>Projects</span>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+            <div class="">
+                <ul class="nav navbar-nav">
+                {% if user.is_authenticated %}
+                    <li><span>
+                    {% if user.first_name %}
+                        {{ user.first_name }} {{ user.last_name }} (@{{ user.get_username }})
+                    {% else %}
+                        @{{ user.get_username }}
+                    {% endif %}
+                    </span></li>
+                    <li><a class="btn btn-outline-light btn-sm" href="{% url 'sign_out'%}">Sign out</a></li>
+                {% else %}
+                    <li><a class="btn btn-outline-light btn-sm" href="{% url 'sign_in'%}">Sign in</a></li>
+                {% endif %}
+                </ul>
+            </div>
+        </div>
+    </header>
+    {% endblock %}
+
+    <div class="layout-page {% block layout %}{% endblock %}">
+        {% block navigation-sidebar %}
+        {% endblock %}
+
+        <div class="content-wrapper">
+            <div class="container-{% block containertype %}xl{% endblock %}">
+                <main class="content">
+                    {% block content %}{% endblock %}
+                </main>
+            </div>
+            {% block content-sidebar %}
+            {% endblock %}
+        </div>
+    </div>
+</body>
+{% endblock %}

--- a/dtf/templates/dtf/page_with_sidebar.html
+++ b/dtf/templates/dtf/page_with_sidebar.html
@@ -1,4 +1,4 @@
-{% extends 'dtf/base.html' %}
+{% extends 'dtf/page_with_header.html' %}
 
 {% block layout %}page-with-navigation-sidebar{% endblock %}
 

--- a/dtf/templates/dtf/users/reset_password.html
+++ b/dtf/templates/dtf/users/reset_password.html
@@ -1,0 +1,43 @@
+{% extends 'dtf/base.html' %}
+
+{% load dtf.custom_filters %}
+
+{% load static %}
+
+{% block head %}
+<link rel="stylesheet" type="text/css" href="{% static 'dtf/users.css' %}">
+{% endblock %}
+
+{% block body %}
+<body class="text-center">
+  <form class="user-form reset-form" action="" method="post" novalidate>
+    {% csrf_token %}
+
+    {% comment %} <img class="mb-4" src="/docs/4.6/assets/brand/bootstrap-solid.svg" alt="" width="72" height="72"> {% endcomment %}
+    <h1 class="h3 mb-3 font-weight-normal">Password reset</h1>
+
+    <p>
+    Forgotten your password? Enter your email address below, and we’ll email instructions for setting a new one.
+    </p>
+
+    {% for hidden_field in form.hidden_fields %}
+      {{ hidden_field }}
+    {% endfor %}
+
+    {% if form.non_field_errors %}
+      <div class="alert alert-danger" role="alert">
+        {% for error in form.non_field_errors %}
+          {{ error }}
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <div class="form-group">
+      <label for="id_email" class="sr-only">Email address</label>
+      {{ form.email|as_bootstrap_field }}
+    </div>
+
+    <button class="btn btn-lg btn-primary btn-block" type="submit">Reset password</button>
+  </form>
+</body>
+{% endblock %}

--- a/dtf/templates/dtf/users/reset_password_complete.html
+++ b/dtf/templates/dtf/users/reset_password_complete.html
@@ -1,0 +1,22 @@
+{% extends 'dtf/base.html' %}
+
+{% load dtf.custom_filters %}
+
+{% load static %}
+
+{% block head %}
+<link rel="stylesheet" type="text/css" href="{% static 'dtf/users.css' %}">
+{% endblock %}
+
+{% block body %}
+<body class="text-center">
+  <div class="user-info">
+    <h1 class="h3 mb-3 font-weight-normal">Password reset complete</h1>
+    <p>Your password has been set.  You may go ahead and log in now.</p>
+
+    <p class="mt-2">
+      <a href="{% url 'sign_in' %}">Login</a>
+    </p>
+  </div>
+</body>
+{% endblock %}

--- a/dtf/templates/dtf/users/reset_password_confirm.html
+++ b/dtf/templates/dtf/users/reset_password_confirm.html
@@ -1,0 +1,46 @@
+{% extends 'dtf/base.html' %}
+
+{% load dtf.custom_filters %}
+
+{% load static %}
+
+{% block head %}
+<link rel="stylesheet" type="text/css" href="{% static 'dtf/users.css' %}">
+{% endblock %}
+
+{% block body %}
+<body class="text-center">
+  <form class="user-form reset-confirm-form" action="" method="post" novalidate>
+    {% csrf_token %}
+
+    {% comment %} <img class="mb-4" src="/docs/4.6/assets/brand/bootstrap-solid.svg" alt="" width="72" height="72"> {% endcomment %}
+    <h1 class="h3 mb-3 font-weight-normal">Set new password</h1>
+
+    <p>
+    Please enter your new password twice so we can verify you typed it in correctly.
+    </p>
+
+    {% for hidden_field in form.hidden_fields %}
+      {{ hidden_field }}
+    {% endfor %}
+
+    {% if form.non_field_errors %}
+      <div class="alert alert-danger" role="alert">
+        {% for error in form.non_field_errors %}
+          {{ error }}
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <div class="form-group">
+      <label for="id_new_password1" class="sr-only">New password</label>
+      {{ form.new_password1|as_bootstrap_field }}
+
+      <label for="id_new_password2" class="sr-only">Confirm password</label>
+      {{ form.new_password2|as_bootstrap_field }}
+    </div>
+
+    <button class="btn btn-lg btn-primary btn-block" type="submit">Change password</button>
+  </form>
+</body>
+{% endblock %}

--- a/dtf/templates/dtf/users/reset_password_done.html
+++ b/dtf/templates/dtf/users/reset_password_done.html
@@ -1,0 +1,19 @@
+{% extends 'dtf/base.html' %}
+
+{% load dtf.custom_filters %}
+
+{% load static %}
+
+{% block head %}
+<link rel="stylesheet" type="text/css" href="{% static 'dtf/users.css' %}">
+{% endblock %}
+
+{% block body %}
+<body class="text-center">
+  <div class="user-info">
+    <h1 class="h3 mb-3 font-weight-normal">Password reset</h1>
+    <p>We’ve emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly.</p>
+    <p>If you don’t receive an email, please make sure you’ve entered the address you registered with, and check your spam folder.</p>
+  </div>
+</body>
+{% endblock %}

--- a/dtf/templates/dtf/users/reset_password_email.html
+++ b/dtf/templates/dtf/users/reset_password_email.html
@@ -1,0 +1,5 @@
+{% extends 'registration/password_reset_email.html' %}
+
+{% block reset_link %}
+{{ protocol }}://{{ domain }}{% url 'reset_password_confirm' uidb64=uid token=token %}
+{% endblock %}

--- a/dtf/templates/dtf/users/sign_in.html
+++ b/dtf/templates/dtf/users/sign_in.html
@@ -1,0 +1,56 @@
+{% extends 'dtf/base.html' %}
+
+{% load dtf.custom_filters %}
+
+{% load static %}
+
+{% block head %}
+<link rel="stylesheet" type="text/css" href="{% static 'dtf/users.css' %}">
+{% endblock %}
+
+{% block body %}
+<body class="text-center">
+  <form class="user-form signin-form" action="{% url 'sign_in' %}" method="post" novalidate>
+    {% csrf_token %}
+
+    {% comment %} <img class="mb-4" src="/docs/4.6/assets/brand/bootstrap-solid.svg" alt="" width="72" height="72"> {% endcomment %}
+    <h1 class="h3 mb-3 font-weight-normal">Please sign in</h1>
+
+    {% for hidden_field in form.hidden_fields %}
+      {{ hidden_field }}
+    {% endfor %}
+
+    {% if form.non_field_errors %}
+      <div class="alert alert-danger" role="alert">
+        {% for error in form.non_field_errors %}
+          {{ error }}
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <div class="form-group">
+      <label for="{{ form.username.id_for_label }}" class="sr-only">{{ form.username.label }}</label>
+      {{ form.username|as_bootstrap_field }}
+
+      <label for="{{ form.password.id_for_label }}" class="sr-only">{{ form.password.label }}</label>
+      {{ form.password|as_bootstrap_field }}
+    </div>
+
+    <div class="form-group form-check">
+      {{ form.remember_me|as_bootstrap_field }}
+      <label class="form-check-label" for="{{ form.remember_me.id_for_label }}">{{ form.remember_me.label }}</label>
+      <div class="float-right">
+        <a href="{% url 'reset_password' %}">Forgot your password?</a>
+      </div>
+    </div>
+
+    <input type="hidden" name="next" value="{{ next }}" />
+
+    <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
+
+    <p class="mt-2">
+      No account yet? <a href="{% url 'sign_up' %}">Create one now</a>
+    </p>
+  </form>
+</body>
+{% endblock %}

--- a/dtf/templates/dtf/users/sign_out.html
+++ b/dtf/templates/dtf/users/sign_out.html
@@ -1,0 +1,25 @@
+{% extends 'dtf/base.html' %}
+
+{% load dtf.custom_filters %}
+
+{% load static %}
+
+{% block head %}
+<link rel="stylesheet" type="text/css" href="{% static 'dtf/users.css' %}">
+{% endblock %}
+
+{% block body %}
+<body class="text-center">
+  <div class="user-info">
+    <h1 class="h3 mb-3 font-weight-normal">Signed out!</h1>
+    <p>You will be redirected in 5 seconds.</p>
+    <a href="{% url 'sign_in'%}">Or click here to sign in again</a>
+  </div>
+
+  <script>
+    setTimeout(function(){
+      window.location.href = '{% url 'home'%}';
+    }, 5000);
+  </script>
+</body>
+{% endblock %}

--- a/dtf/templates/dtf/users/sign_up.html
+++ b/dtf/templates/dtf/users/sign_up.html
@@ -1,0 +1,64 @@
+{% extends 'dtf/base.html' %}
+
+{% load dtf.custom_filters %}
+
+{% load static %}
+
+{% block head %}
+<link rel="stylesheet" type="text/css" href="{% static 'dtf/users.css' %}">
+{% endblock %}
+
+{% block body %}
+<body class="text-center">
+  <form class="user-form signup-form" action="{% url 'sign_up' %}" method="post" novalidate>
+    {% csrf_token %}
+
+    {% comment %} <img class="mb-4" src="/docs/4.6/assets/brand/bootstrap-solid.svg" alt="" width="72" height="72"> {% endcomment %}
+    <h1 class="h3 mb-3 font-weight-normal">Create new account</h1>
+
+    {% for hidden_field in form.hidden_fields %}
+      {{ hidden_field }}
+    {% endfor %}
+
+    {% if form.non_field_errors %}
+      <div class="alert alert-danger" role="alert">
+        {% for error in form.non_field_errors %}
+          {{ error }}
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <div class="form-row">
+      <div class="form-group col">
+        <label for="{{ form.first_name.id_for_label }}" class="sr-only">{{ form.first_name.label }}</label>
+        {{ form.first_name|as_bootstrap_field }}
+      </div>
+      <div class="form-group col">
+        <label for="{{ form.last_name.id_for_label }}" class="sr-only">{{ form.last_name.label }}</label>
+        {{ form.last_name|as_bootstrap_field }}
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="{{ form.username.id_for_label }}" class="sr-only">{{ form.username.label }}</label>
+      {{ form.username|as_bootstrap_field }}
+    </div>
+
+    <div class="form-group">
+      <label for="{{ form.email.id_for_label }}" class="sr-only">{{ form.email.label }}</label>
+      {{ form.email|as_bootstrap_field }}
+    </div>
+
+    <div class="form-group">
+      <label for="{{ form.password.id_for_label }}" class="sr-only">{{ form.password.label }}</label>
+      {{ form.password|as_bootstrap_field }}
+    </div>
+
+    <button class="btn btn-lg btn-primary btn-block" type="submit">Register</button>
+
+    <p class="mt-2">
+      You have an account already? <a href="{% url 'sign_in' %}">Login</a>
+    </p>
+  </form>
+</body>
+{% endblock %}

--- a/dtf/templatetags/dtf/custom_filters.py
+++ b/dtf/templatetags/dtf/custom_filters.py
@@ -159,6 +159,8 @@ def add_bootstrap_class(field, add_class=""):
         "checkbox" : "form-check-input",
         "url" : "form-control",
         "textarea" : "form-control",
+        "password" : "form-control",
+        "email" : "form-control",
     }
 
     current_class = field.field.widget.attrs.get('class', None)

--- a/dtf/tests/test_api.py
+++ b/dtf/tests/test_api.py
@@ -20,6 +20,7 @@ from django.test import TestCase, Client
 from django.urls import reverse
 from django.utils.text import slugify
 from django.db import transaction
+from django.contrib.auth.models import User
 
 from dtf.models import Project, TestResult, ReferenceSet, TestReference, Submission, ProjectSubmissionProperty, Webhook
 from dtf.serializers import ProjectSerializer
@@ -33,6 +34,10 @@ from dtf.serializers import WebhookSerializer
 client = Client()
 
 class ApiTestCase(TestCase):
+
+    def setUp(self):
+        self.testuser = User.objects.create_user(username='test')
+        client.force_login(self.testuser)
 
     def post(self, url, payload):
         response = client.post(
@@ -83,6 +88,7 @@ class ApiTestCase(TestCase):
 class ProjectsApiTest(ApiTestCase):
     """ Test module for Project model interaction with API """
     def setUp(self):
+        super().setUp()
         self.invalid_payload = {
             'not_a_name':'no name given'
         }
@@ -141,6 +147,7 @@ class ProjectsApiTest(ApiTestCase):
 
 class ProjectApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         self.project_1_name = "Test Project 1"
         self.project_2_name = "Test/Project#?2"
         self.project_1_slug = "test-project-1"
@@ -198,6 +205,7 @@ class ProjectApiTest(ApiTestCase):
 
 class ProjectSubmissionPropertiesApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project", "test-project")
         self.project_id = data['id']
         self.url = reverse('api_project_submission_properties', kwargs={'project_id' : self.project_id})
@@ -242,6 +250,7 @@ class ProjectSubmissionPropertiesApiTest(ApiTestCase):
 
 class ProjectSubmissionPropertyApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project", "test-project")
         self.project_id = data['id']
         create_url = reverse('api_project_submission_properties', kwargs={'project_id' : self.project_id})
@@ -295,6 +304,7 @@ class SubmissionsApiTest(ApiTestCase):
     """ Test module for submissions"""
 
     def setUp(self):
+        super().setUp()
         self.project_name = "Submission Project"
         self.project_slug = "submission-project"
         _, data = self.create_project(self.project_name, self.project_slug)
@@ -417,6 +427,7 @@ class SubmissionsApiTest(ApiTestCase):
 
 class SubmissionApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project", "test-project")
         self.project_id = data['id']
 
@@ -471,6 +482,7 @@ class TestResultsApiTest(ApiTestCase):
     """ Test module for submitting test results via the API """
 
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project", "test-project")
         self.project_id = data['id']
         _, data = self.create_submission(project_id=self.project_id)
@@ -659,6 +671,7 @@ class TestResultsApiTest(ApiTestCase):
 
 class TestResultApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project", "test-project")
         self.project_id = data['id']
         _, data = self.create_submission(project_id=self.project_id)
@@ -719,6 +732,7 @@ class TestResultApiTest(ApiTestCase):
 
 class TestResultHistoryApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project", "test-project")
         self.project_id = data['id']
         property_url = reverse('api_project_submission_properties', kwargs={'project_id' : self.project_id})
@@ -846,6 +860,7 @@ class TestResultHistoryApiTest(ApiTestCase):
 
 class ProjectTestResultsApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project", "test-project")
         self.project_id = data['id']
         _, data = self.create_submission(project_id=self.project_id)
@@ -871,6 +886,7 @@ class ProjectTestResultsApiTest(ApiTestCase):
 
 class TestResultApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project", "test-project")
         self.project_id = data['id']
         _, data = self.create_submission(project_id=self.project_id)
@@ -932,6 +948,7 @@ class TestResultApiTest(ApiTestCase):
 
 class ReferenceSetsApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         # Create simple project without properties
         _, data = self.create_project("Test Project 1", "test-project-1")
         self.project_1_id = data['id']
@@ -1069,6 +1086,7 @@ class ReferenceSetsApiTest(ApiTestCase):
 
 class ReferenceSetApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project", "test-project")
         self.project_id = data['id']
         create_url = reverse('api_project_references', kwargs={'project_id' : self.project_id})
@@ -1138,6 +1156,7 @@ class ReferenceSetApiTest(ApiTestCase):
 
 class TestReferencesApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project 1", "test-project-1")
         self.project_id = data['id']
         self.project = Project.objects.get(id=data['id'])
@@ -1280,6 +1299,7 @@ class TestReferencesApiTest(ApiTestCase):
 
 class TestReferenceApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project 1", "test-project-1")
         self.project_id = data['id']
         self.project = Project.objects.get(id=data['id'])
@@ -1393,6 +1413,7 @@ class TestReferenceApiTest(ApiTestCase):
 
 class WebhooksApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project 1", "test-project-1")
         self.project_1_id = data['id']
         self.project_1 = Project.objects.get(id=self.project_1_id)
@@ -1438,6 +1459,7 @@ class WebhooksApiTest(ApiTestCase):
 
 class WebhookApiTest(ApiTestCase):
     def setUp(self):
+        super().setUp()
         _, data = self.create_project("Test Project 1", "test-project-1")
         self.project_id = data['id']
         create_url = reverse('api_project_webhooks', kwargs={'project_id' : self.project_id})

--- a/dtf/urls.py
+++ b/dtf/urls.py
@@ -13,8 +13,18 @@ urlpatterns = [
     path('admin/', admin.site.urls),
 
     path('', RedirectView.as_view(pattern_name='projects', permanent=False), name="home"),
+
     path('projects/', views.view_projects, name='projects'),
     path('projects/new', views.view_new_project, name='new_project'),
+
+    path('users/sign_up', views.view_sign_up, name='sign_up'),
+    path('users/sign_in', views.SignInView.as_view(), name='sign_in'),
+    path('users/sign_out', views.SignOutView.as_view(), name='sign_out'),
+    path('users/password/reset', views.ResetPasswordView.as_view(), name='reset_password'),
+    path('users/password/reset_done', views.ResetPasswordDoneView.as_view(), name='reset_password_done'),
+    path('users/password/confirm/<uidb64>/<token>/', views.ResetPasswordConfirmView.as_view(), name='reset_password_confirm'),
+    path('users/password/reset_complete', views.ResetPasswordCompleteView.as_view(), name='reset_password_complete'),
+
     path('<str:project_slug>', RedirectView.as_view(pattern_name='project_submissions', permanent=False), name='project_details'),
     path('<str:project_slug>/settings', views.view_project_settings, name='project_settings'),
     path('<str:project_slug>/webhook/<int:webhook_id>/log', views.view_webhook_log, name='webhook_log'),

--- a/dtf/urls.py
+++ b/dtf/urls.py
@@ -36,6 +36,9 @@ urlpatterns = [
     path('<str:project_slug>/reference_sets/<int:reference_id>', views.view_reference_set_details, name='reference_set_details'),
     path('<str:project_slug>/test_references/<int:test_id>', views.view_test_reference_details, name='test_reference_details'),
 
+    path('api/users', api.UserList.as_view(), name='api_users'),
+    path('api/users/<str:id>', api.UserDetail.as_view(), name='api_user'),
+
     path('api/projects', api.ProjectList.as_view(), name='api_projects'),
     path('api/projects/<str:id>', api.ProjectDetail.as_view(), name='api_project'),
 

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -4,6 +4,7 @@ from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponseRedirect, JsonResponse, HttpResponse, Http404
 from django.urls import reverse, reverse_lazy
 from django.contrib.auth.views import LoginView, LogoutView, PasswordResetView, PasswordResetDoneView, PasswordResetConfirmView, PasswordResetCompleteView
+from django.contrib.auth.decorators import login_required
 from django.conf import settings
 
 from rest_framework import status
@@ -71,6 +72,7 @@ def view_projects(request):
     projects = Project.objects.order_by('-name')
     return render(request, 'dtf/view_projects.html', {'projects':projects})
 
+@login_required
 def view_new_project(request):
     if request.method == 'POST':
         form = NewProjectForm(request.POST)
@@ -83,6 +85,7 @@ def view_new_project(request):
         'form': form}
     )
 
+@login_required
 def view_project_settings(request, project_slug):
     project = get_object_or_404(Project, slug=project_slug)
     properties = project.properties.all()
@@ -154,6 +157,7 @@ def view_project_settings(request, project_slug):
     })
 
 
+@login_required
 def view_webhook_log(request, project_slug, webhook_id):
     project = get_object_or_404(Project, slug=project_slug)
     webhook = project.webhooks.get(id=webhook_id)
@@ -161,6 +165,7 @@ def view_webhook_log(request, project_slug, webhook_id):
         'webhook': webhook,
     })
 
+@login_required
 def view_project_submissions(request, project_slug):
     project = get_object_or_404(Project, slug=project_slug)
     properties = ProjectSubmissionProperty.objects.filter(project=project)
@@ -176,6 +181,7 @@ def view_project_submissions(request, project_slug):
         'submissions':submissions
     })
 
+@login_required
 def view_test_result_details(request, project_slug, test_id):
     project = get_object_or_404(Project, slug=project_slug)
     test_result = get_object_or_404(TestResult, pk=test_id)
@@ -220,6 +226,7 @@ def view_test_result_details(request, project_slug, test_id):
         # 'nav_data':nav_data
     })
 
+@login_required
 def view_submission_details(request, project_slug, submission_id):
     project = get_object_or_404(Project, slug=project_slug)
     submission = get_object_or_404(Submission, pk=submission_id)
@@ -229,6 +236,7 @@ def view_submission_details(request, project_slug, submission_id):
         'submission':submission
     })
 
+@login_required
 def view_project_reference_sets(request, project_slug):
     project = get_object_or_404(Project, slug=project_slug)
     properties = ProjectSubmissionProperty.objects.filter(project=project)
@@ -244,6 +252,7 @@ def view_project_reference_sets(request, project_slug):
         'reference_sets':reference_sets
     })
 
+@login_required
 def view_reference_set_details(request, project_slug, reference_id):
     project = get_object_or_404(Project, slug=project_slug)
     reference_set = get_object_or_404(ReferenceSet, pk=reference_id)
@@ -253,6 +262,7 @@ def view_reference_set_details(request, project_slug, reference_id):
         'reference_set': reference_set
     })
 
+@login_required
 def view_test_reference_details(request, project_slug, test_id):
     project = get_object_or_404(Project, slug=project_slug)
     test_reference = get_object_or_404(TestReference, pk=test_id)
@@ -264,6 +274,7 @@ def view_test_reference_details(request, project_slug, test_id):
         'test_reference': test_reference
     })
 
+@login_required
 def view_test_measurement_history(request, project_slug, test_id):
     project = get_object_or_404(Project, slug=project_slug)
     test_result = get_object_or_404(TestResult, pk=test_id)

--- a/settings/common.py
+++ b/settings/common.py
@@ -77,8 +77,8 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'dtf.wsgi.application'
 
-
-
+LOGIN_URL = '/users/sign_in'
+LOGIN_REDIRECT_URL = '/'
 
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators

--- a/settings/common.py
+++ b/settings/common.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework.authtoken',
 #    'lending.apps.LendingConfig'
     'dtf.apps.DtfConfig'
 ]
@@ -41,8 +42,15 @@ REST_FRAMEWORK = {
     # or allow read-only access for unauthenticated users.
     # voss: im not sure what this does for me right now
     # docs https://www.django-rest-framework.org/api-guide/permissions/#setting-the-permission-policy
-    # 'DEFAULT_PERMISSION_CLASSES': [],
-    'TEST_REQUEST_DEFAULT_FORMAT': 'json'
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated'
+    ],
 }
 
 

--- a/settings/development.py
+++ b/settings/development.py
@@ -21,5 +21,7 @@ DATABASES = {
     }
 }
 
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 default_database = os.environ.get('DTF_DEFAULT_DATABASE', 'main')
 DATABASES['default'] = DATABASES[default_database]

--- a/setup-demo-db.py
+++ b/setup-demo-db.py
@@ -41,7 +41,7 @@ if os.path.exists(db_path):
 os.environ["DTF_ENABLE_WEBHOOKS"] = "0"
 
 os.system(f"{sys.executable} {manage_script_path} migrate --database {args.db}")
-os.system(f"{sys.executable} {manage_script_path} loaddata --database {args.db} demo-user") # Name: root PW: test1234
+os.system(f"{sys.executable} {manage_script_path} loaddata --database {args.db} demo-user") # Name: root PW: test1234 ; Name: demo PW: demopassword
 os.system(f"{sys.executable} {manage_script_path} loaddata --database {args.db} demo-project")
 os.system(f"{sys.executable} {manage_script_path} loaddata --database {args.db} demo-submissions")
 os.system(f"{sys.executable} {manage_script_path} loaddata --database {args.db} demo-webhook-log")


### PR DESCRIPTION
This MR introduces initial support for users.

The default django `User` model is used to represent users. On the API side two new (read-only) endpoints have been added:

```
api/users
api/users/<str:id>
```

These can be used to retrieve available users on the server. Currently users can not be added or modified through the REST API.

On the front-end side all required views for user management  (signin/signup/password managment/...) have been added.

An important change introduced is that all APIs and views do now require successful user authentication. An anonymous user will  not be able to retrieve any data from the server (neither via the GUI, nor the REST API).