### PR TITLE
Improve front-end views for users with reduced permissions

### DIFF
--- a/dtf/permissions.py
+++ b/dtf/permissions.py
@@ -43,6 +43,12 @@ def has_required_model_role(user, project, model, operation):
 
     return _is_sufficient_role(membership.role, required_role=required_role)
 
+def get_model_permissions(user, project, model, operations=['add', 'change', 'delete']):
+    result = {}
+    for operation in operations:
+        result[operation] = has_required_model_role(user, project, model, operation)
+    return result
+
 def check_required_model_role(user, project, model, operation):
     if not has_required_model_role(user, project, model, operation):
         raise PermissionDenied

--- a/dtf/templates/dtf/errors/403.html
+++ b/dtf/templates/dtf/errors/403.html
@@ -1,0 +1,7 @@
+{% extends 'dtf/page_no_sidebar.html' %}
+
+{% block content %}
+<body class="text-center">
+    <h1>403 Forbidden</h1>
+</body>
+{% endblock %}

--- a/dtf/templates/dtf/project_members.html
+++ b/dtf/templates/dtf/project_members.html
@@ -22,8 +22,10 @@
 </div>
 
 <div class="mt-3">
+  <h3>Project Members</h3>
+
+  {% if member_permissions.add %}
   <section class="mt-2">
-    <h3>Project Members</h3>
     <p>Add new members to this project:</p>
     <form id="member_form_id" novalidate>
       {% csrf_token %}
@@ -63,6 +65,7 @@
       </div>
     </form>
   </section>
+  {% endif %}
 
   <section class="mt-2">
     <h4>Current Members</h4>
@@ -114,6 +117,7 @@
               .append($('<td>')
                   .attr('class', 'text-right fit')
                   .append($('<div>')
+                      {% if member_permissions.change %}
                       .append($('<button>')
                           .attr('class', 'btn btn-outline-dark btn-sm me-md-1 ms-md-1')
                           .attr('onclick', 'startEditMember(' + data['id'] + ')')
@@ -121,6 +125,8 @@
                               .attr('class', 'bi bi-pencil')
                           )
                       )
+                      {% endif %}
+                      {% if member_permissions.delete %}
                       .append($('<button>')
                           .attr('class', 'btn btn-danger btn-sm me-md-1 ms-md-1')
                           .attr('onclick', 'deleteMember(' + data['id'] + ')')
@@ -128,6 +134,7 @@
                               .attr('class', 'bi bi-trash')
                           )
                       )
+                      {% endif %}
                   )
               )
         );

--- a/dtf/templates/dtf/project_settings.html
+++ b/dtf/templates/dtf/project_settings.html
@@ -62,8 +62,9 @@
           </div>
         </div>
       </div>
-
+      {% if project_permissions.change %}
       <input type="submit" value="Save" name="edit" class="btn btn-success btn-sm">
+      {% endif %}
     </form>
   </div>
 </section>
@@ -77,6 +78,7 @@
   </div>
 
   <div id="properties" class="section-content collapse">
+    {% if property_permissions.change or property_permissions.add %}
     <form id="property_form_id" novalidate>
       {% csrf_token %}
 
@@ -132,16 +134,21 @@
 
       <div class="row mb-3">
         <div class="col">
+          {% if property_permissions.add %}
           <input type="submit" value="Add property" name="add" class="btn btn-success btn-sm">
+          {% endif %}
+          {% if property_permissions.change %}
           <input type="submit" value="Save changes" name="edit" class="btn btn-success btn-sm" hidden>
+          {% endif %}
         </div>
         <div class="col-auto">
           <a id="property_edit_cancel" class="btn btn-outline-secondary btn-sm" onclick="cancelEditProperty()" hidden>Cancel</a>
         </div>
       </div>
     </form>
+    {% endif %}
 
-    <table id="property_table" class="table table-hover table-sm mt-md-3">
+    <table id="property_table" class="table table-hover table-sm">
       <thead>
         <tr>
           <th scope="col" class="col-auto">Name</th>
@@ -166,6 +173,7 @@
   </div>
 
   <div id="webhooks" class="section-content collapse">
+    {% if webhook_permissions.change or webhook_permissions.add %}
     <form id="webhook_form_id" novalidate>
       {% csrf_token %}
 
@@ -229,16 +237,21 @@
 
       <div class="row mb-3">
         <div class="col">
+          {% if webhook_permissions.add %}
           <input type="submit" value="Add webhook" name="add" class="btn btn-success btn-sm">
+          {% endif %}
+          {% if webhook_permissions.change %}
           <input type="submit" value="Save changes" name="edit" class="btn btn-success btn-sm" hidden>
+          {% endif %}
         </div>
         <div class="col-auto">
           <a id="webhook_edit_cancel" class="btn btn-outline-secondary btn-sm" onclick="cancelEditWebhook()" hidden>Cancel</a>
         </div>
       </div>
     </form>
+    {% endif %}
 
-    <table id="webhook_table" class="table table-hover table-sm mt-md-3">
+    <table id="webhook_table" class="table table-hover table-sm">
       <thead>
         <tr>
           <th scope="col" class="col-auto">Name</th>
@@ -289,11 +302,13 @@
                   .append($('<span>')
                       .text(data['name'])
                   )
+                  {% if webhook_log_permissions.view %}
                   .append($('<a>')
                       .attr('href', '{% url 'webhook_log' project.slug 1234%}'.replace('1234', data['id']))
                       .attr('class', 'me-md-1 ms-md-1 badge ' + status_badge_class)
                       .text(data['status'])
                   )
+                  {% endif %}
               )
               .append($('<td>')
                   .text(data['url'])
@@ -301,6 +316,7 @@
               .append($('<td>')
                   .attr('class', 'text-right fit')
                   .append($('<div>')
+                      {% if webhook_permissions.change %}
                       .append($('<button>')
                           .attr('class', 'btn btn-outline-success btn-sm me-md-1 ms-md-1')
                           .append($('<i>')
@@ -314,6 +330,8 @@
                               .attr('class', 'bi bi-pencil')
                           )
                       )
+                      {% endif %}
+                      {% if webhook_permissions.delete %}
                       .append($('<button>')
                           .attr('class', 'btn btn-danger btn-sm me-md-1 ms-md-1')
                           .attr('onclick', 'deleteWebhook(' + data['id'] + ')')
@@ -321,6 +339,7 @@
                               .attr('class', 'bi bi-trash')
                           )
                       )
+                      {% endif %}
                   )
               )
         );
@@ -362,6 +381,7 @@
               .append($('<td>')
                   .attr('class', 'text-right fit')
                   .append($('<div>')
+                      {% if webhook_permissions.change %}
                       .append($('<button>')
                           .attr('class', 'btn btn-outline-dark btn-sm me-md-1 ms-md-1')
                           .attr('onclick', 'startEditProperty(' + data['id'] + ')')
@@ -369,6 +389,8 @@
                               .attr('class', 'bi bi-pencil')
                           )
                       )
+                      {% endif %}
+                      {% if webhook_permissions.delete %}
                       .append($('<button>')
                           .attr('class', 'btn btn-danger btn-sm me-md-1 ms-md-1')
                           .attr('onclick', 'deleteProperty(' + data['id'] + ')')
@@ -376,6 +398,7 @@
                               .attr('class', 'bi bi-trash')
                           )
                       )
+                      {% endif %}
                   )
               )
         

--- a/dtf/templates/dtf/project_sidebar.html
+++ b/dtf/templates/dtf/project_sidebar.html
@@ -9,30 +9,38 @@
     </div>
 
     <ul>
+        {% if 'submissions' in project_sidebar_items %}
         <li class="{% if active_page == 'submissions' %}active{% endif %}">
             <a href="{% url 'project_submissions' project.slug %}">
                 <span class="item-icon"><i class="bi bi-box-arrow-in-right"></i></span>
                 <span class="item-name">Submissions</span>
             </a>
         </li>
+        {% endif %}
+        {% if 'references' in project_sidebar_items %}
         <li class="{% if active_page == 'references' %}active{% endif %}">
             <a href="{% url 'project_reference_sets' project.slug %}">
                 <span class="item-icon"><i class="bi bi-star"></i></span>
                 <span class="item-name">References</span>
             </a>
         </li>
+        {% endif %}
+        {% if 'members' in project_sidebar_items %}
         <li class="{% if active_page == 'members' %}active{% endif %}">
             <a href="{% url 'project_members' project.slug %}">
                 <span class="item-icon"><i class="bi bi-people"></i></span>
                 <span class="item-name">Members</span>
             </a>
         </li>
+        {% endif %}
+        {% if 'settings' in project_sidebar_items %}
         <li class="{% if active_page == 'settings' %}active{% endif %}">
             <a href="{% url 'project_settings' project.slug %}">
                 <span class="item-icon"><i class="bi bi-gear"></i></span>
                 <span class="item-name">Settings</span>
             </a>
         </li>
+        {% endif %}
     </ul>
 
     <a class="toggle-sidebar-button border-top" type="button" onclick="toggleNavigationSidebar()">

--- a/dtf/templates/dtf/test_result_details.html
+++ b/dtf/templates/dtf/test_result_details.html
@@ -150,9 +150,11 @@ function toggleAllBoxes(){
         {% endwith %}
     </div>
 
+    {% if test_reference_permissions.add or test_reference_permissions.change %}
     <div class="col-md-auto">
         <button class="btn btn-sm btn-primary btn-lg active" onclick="updateReferences()">Update selected references</button>
     </div>
+    {% endif %}
 </div>
 
 <div class="mt-3 pb-1">
@@ -179,9 +181,11 @@ function toggleAllBoxes(){
         <th class="noselect">
             Global reference
         </th>
+        {% if test_reference_permissions.add or test_reference_permissions.change %}
         <th class="noselect fit sorter-false">
             <input class="ms-2 me-2" id="allBox" type="checkbox" onclick="toggleAllBoxes()" autocomplete="off"/>
         </th>
+        {% endif %}
     </tr>
     </thead>
     <tbody>
@@ -211,6 +215,7 @@ function toggleAllBoxes(){
             <td>
                 {{ parameter.reference|as_measurement_entry:test_result.submission.project }}
             </td>
+            {% if test_reference_permissions.add or test_reference_permissions.change %}
             <td>
                 {% if parameter.test %}
                     <input id="{{ parameter.name }}" class="ms-2 me-2 parameterBox" type="checkbox" pindex="{{ forloop.counter0 }}" autocomplete="off"/>
@@ -218,6 +223,7 @@ function toggleAllBoxes(){
                     <input id="{{ parameter.name }}" class="ms-2 me-2 parameterBox" type="checkbox" pindex="" autocomplete="off"/>
                 {% endif %}
             </td>
+            {% endif %}
         </tr>
     {% endfor %}
     </tbody>

--- a/dtf/urls.py
+++ b/dtf/urls.py
@@ -72,3 +72,5 @@ urlpatterns = [
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)
+
+handler403 = 'dtf.views.view_error_403'

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -391,3 +391,10 @@ class TestMeasurementHistoryView(ProjectViewMixin, ProjectPermissionRequiredMixi
                                         measurement_name=measurement_name,
                                         limit=limit,
                                         measurement_global_reference=measurement_global_reference)
+
+#
+# Error views
+#
+
+def view_error_403(request, *args, **argv):
+    return render(request, 'dtf/errors/403.html')

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -225,7 +225,11 @@ def view_project_settings(request, project_slug):
         'properties' : properties,
         'property_form': property_form,
         'webhooks' : webhooks,
-        'webhook_form': webhook_form
+        'webhook_form': webhook_form,
+        'project_permissions': get_model_permissions(request.user, project, Project),
+        'property_permissions': get_model_permissions(request.user, project, ProjectSubmissionProperty),
+        'webhook_permissions': get_model_permissions(request.user, project, Webhook),
+        'webhook_log_permissions': get_model_permissions(request.user, project, WebhookLogEntry, operations=['view'])
     })
 
 

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -19,7 +19,21 @@ from dtf.serializers import WebhookSerializer
 from dtf.models import TestResult, Membership, Project, ReferenceSet, TestReference, Submission, ProjectSubmissionProperty, Webhook, WebhookLogEntry
 from dtf.functions import create_view_data_from_test_references, create_reference_query
 from dtf.forms import NewProjectForm, ProjectSettingsForm, ProjectSubmissionPropertyForm, MembershipForm, WebhookForm, NewUserForm, LoginForm, ResetPasswordForm, PasswordSetForm
-from dtf.permissions import ProjectPermissionRequiredMixin, get_model_permissions, check_required_model_role
+from dtf.permissions import ProjectPermissionRequiredMixin, has_required_model_role, get_model_permissions, check_required_model_role
+
+def _get_project_sidebar_items(user, project):
+    result = []
+    if has_required_model_role(user, project, Submission, 'view'):
+        result.append('submissions')
+    if has_required_model_role(user, project, ReferenceSet, 'view'):
+        result.append('references')
+    if has_required_model_role(user, project, Membership, 'view'):
+        result.append('members')
+    if has_required_model_role(user, project, Project, 'view') and \
+       has_required_model_role(user, project, ProjectSubmissionProperty, 'view') and \
+       has_required_model_role(user, project, Webhook, 'view'):
+        result.append('settings')
+    return result
 
 #
 # User views
@@ -74,6 +88,11 @@ class ProjectViewMixin():
 
     def get_project(self):
         return get_object_or_404(Project, slug=self.kwargs[self.project_slug_url_kwarg])
+
+    def get_context_data(self, **kwargs):
+        project = self.get_project()
+        return super().get_context_data(**kwargs,
+                                        project_sidebar_items=_get_project_sidebar_items(self.request.user, project))
 
 class ProjectListView(generic.ListView):
     template_name = 'dtf/view_projects.html'
@@ -226,6 +245,7 @@ def view_project_settings(request, project_slug):
         'property_form': property_form,
         'webhooks' : webhooks,
         'webhook_form': webhook_form,
+        'project_sidebar_items': _get_project_sidebar_items(request.user, project),
         'project_permissions': get_model_permissions(request.user, project, Project),
         'property_permissions': get_model_permissions(request.user, project, ProjectSubmissionProperty),
         'webhook_permissions': get_model_permissions(request.user, project, Webhook),

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -324,7 +324,8 @@ class TestResultDetailView(ProjectViewMixin, ProjectPermissionRequiredMixin, gen
                                         test_result=test_result,
                                         property_values=str(property_values),
                                         #nav_data=nav_data,
-                                        data=data)
+                                        data=data,
+                                        test_reference_permissions=get_model_permissions(self.request.user, project, TestReference))
 
 class SubmissionDetailView(ProjectViewMixin, ProjectPermissionRequiredMixin, generic.DetailView):
     template_name = 'dtf/submission_details.html'

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -19,7 +19,7 @@ from dtf.serializers import WebhookSerializer
 from dtf.models import TestResult, Membership, Project, ReferenceSet, TestReference, Submission, ProjectSubmissionProperty, Webhook, WebhookLogEntry
 from dtf.functions import create_view_data_from_test_references, create_reference_query
 from dtf.forms import NewProjectForm, ProjectSettingsForm, ProjectSubmissionPropertyForm, MembershipForm, WebhookForm, NewUserForm, LoginForm, ResetPasswordForm, PasswordSetForm
-from dtf.permissions import ProjectPermissionRequiredMixin, check_required_model_role
+from dtf.permissions import ProjectPermissionRequiredMixin, get_model_permissions, check_required_model_role
 
 #
 # User views
@@ -142,7 +142,9 @@ class ProjectMembersView(ProjectViewMixin, ProjectPermissionRequiredMixin, gener
 
     def get_context_data(self, **kwargs):
         project = self.get_project()
-        return super().get_context_data(**kwargs, project=project)
+        return super().get_context_data(**kwargs,
+                                        project=project,
+                                        member_permissions=get_model_permissions(self.request.user, project, Membership))
 
 @login_required
 def view_project_settings(request, project_slug):


### PR DESCRIPTION
This PR improves the front-end views in such a fashion that users with less permission do not get to see pages are parts of pages that they have no access to anyways (e.g. a guest user cannot add members to a project).