### PR TITLE
Dynamic tests results table

### DIFF
--- a/dtf/api.py
+++ b/dtf/api.py
@@ -323,7 +323,8 @@ class ProjectReferenceSetTestReferenceDetail(generics.RetrieveUpdateDestroyAPIVi
             request.data['default_source'])
         try:
             test_references.save()
-            return Response({}, status=status.HTTP_200_OK)
+            serializer = self.get_serializer(test_references)
+            return Response(serializer.data, status=status.HTTP_200_OK)
         except Exception as err:
             return Response(str(err), status=status.HTTP_400_BAD_REQUEST)
 

--- a/dtf/functions.py
+++ b/dtf/functions.py
@@ -28,47 +28,6 @@ def fill_result_default_values(results, test_name, submission):
             result['status'] = 'unknown'
     return results
 
-def create_view_data_from_test_references(test_results, global_references):
-    view_data = []
-    for item in test_results:
-
-        if 'value' in item and item['value'] is not None:
-            test = {
-                'value': item['value']
-            }
-        else:
-            test = None
-
-        reference_on_submission = None
-        if 'reference' in item and item['reference'] is not None:
-            if reference_on_submission is None:
-                reference_on_submission = {}
-            reference_on_submission['value'] = item['reference']
-        if 'reference_source' in item and item['reference_source'] is not None:
-            if reference_on_submission is None:
-                reference_on_submission = {}
-            reference_on_submission['source'] = item['reference_source']
-
-        global_reference = global_references.get(item['name'])
-        if global_reference is not None:
-            reference  = {
-                'value': global_reference['value']
-            }
-            if 'source' in global_reference:
-                reference['source'] = global_reference['source']
-        else:
-            reference = None
-
-        view_data.append({
-            'name': item['name'],
-            'status': item['status'],
-            'test': test,
-            'reference_on_submission': reference_on_submission,
-            'reference': reference,
-        })
-
-    return view_data
-
 def get_project_by_id(project_id, queryset):
     """
     Retrieve a project by its Id. Returns None if no project is found.

--- a/dtf/static/dtf/badge.js
+++ b/dtf/static/dtf/badge.js
@@ -1,0 +1,36 @@
+
+function renderStatusBadge(status) {
+    const statusToBadgeClass = {
+        successful: "text-success border-success",
+        unstable:   "text-warning border-warning",
+        failed:     "text-danger border-danger",
+        broken:     "text-danger border-danger",
+        unknown:    "text-secondary border-secondary",
+        skip:       "text-info border-info"
+    }
+    const statusToIconClass = {
+        successful: "bi-check-circle-fill",
+        unstable:   "bi-exclamation-circle-fill",
+        failed:     "bi-x-circle-fill",
+        broken:     "bi-dash-circle-fill",
+        unknown:    "bi-question-circle-fill",
+        skip:       "bi-slash-circle-fill"
+    }
+
+    let badgeClass = statusToBadgeClass[status];
+    if(badgeClass === undefined) {
+        badgeClass = statusToBadgeClass.unknown;
+    }
+
+    let iconClass = statusToIconClass[status];
+    if(iconClass === undefined) {
+        iconClass = statusToIconClass.unknown;
+    }
+
+    return $('<span>')
+        .attr('class', `badge border ${badgeClass}`)
+        .append($('<i>')
+            .attr('class', `bi ${iconClass}`)
+        )
+        .append(` ${status}`)
+}

--- a/dtf/static/dtf/duration.js
+++ b/dtf/static/dtf/duration.js
@@ -1,0 +1,44 @@
+
+const iso8601DurationRegex = /^(?<sign>[-+]?)P(?:(?<days>\d+(\.\d+)?)D)?(?:T(?:(?<hours>\d+(\.\d+)?)H)?(?:(?<minutes>\d+(\.\d+)?)M)?(?:(?<seconds>\d+(\.\d+)?)S)?)?$/u
+
+function parseISO8601Duration(iso8601DurationStr) {
+    var matches = iso8601DurationRegex.exec(iso8601DurationStr);
+
+    return {
+        sign: matches.groups.sign === undefined ? '+' : matches.groups.sign,
+        days: matches.groups.days === undefined ? 0 : parseFloat(matches.groups.days),
+        hours: matches.groups.hours === undefined ? 0 : parseFloat(matches.groups.hours),
+        minutes: matches.groups.minutes === undefined ? 0 : parseFloat(matches.groups.minutes),
+        seconds: matches.groups.seconds === undefined ? 0 : parseFloat(matches.groups.seconds)
+    };
+}
+
+function totalSeconds(duration) {
+    return (duration.sign === '-' ? -1 : 1) *
+        (duration.days*24*60*60 +
+        duration.hours*60*60 +
+        duration.minutes*60 + 
+        duration.seconds);
+}
+
+function printISO8601Duration(duration) {
+
+    const hh = String(duration.hours);
+    const mm = String(duration.minutes).padStart(2, '0');
+    const ss = String(Math.floor(duration.seconds)).padStart(2, '0');
+
+    result = `${hh}:${mm}:${ss}`;
+
+    if(duration.days > 0) {
+        plural = (duration.days > 1) ? 's' : '';
+        result = `${duration.days} day${plural}` + result;
+    }
+
+    let ms = Math.round((duration.seconds % 1) * 1000000);
+    if(ms >= 0) {
+        ms = String(ms).padStart(6, '0')
+        result += `.${ms}`;
+    }
+
+    return result;
+}

--- a/dtf/static/dtf/results_table.js
+++ b/dtf/static/dtf/results_table.js
@@ -2,6 +2,8 @@
 function buildResultsTable(projectSlug, testId, results, references, canUpdate) {
     let tableBody = $("#resultsTable").find('tbody');
 
+    tableBody.empty();
+
     results.forEach(function (result, resultIndex) {
 
         let reference = references[result['name']];

--- a/dtf/static/dtf/results_table.js
+++ b/dtf/static/dtf/results_table.js
@@ -139,10 +139,18 @@ function postReferenceUpdate(csrfToken, testName, testId, testResults, reference
         url: url,
         data: JSON.stringify(data),
         success: function(result) {
+            $.toast({
+                type: 'success',
+                content: `Successfully updated ${updatedCount} references.`
+            });
             updateResultsTableReferences(projectSlug, testResults, result['references']);
             uncheckAllBoxes();
         },
         error: function(result) {
+            $.toast({
+                type: 'danger',
+                content: `Failed to update ${updatedCount} references.`
+            });
             console.log(result);
         }
     });
@@ -165,7 +173,10 @@ function updateReferences(csrfToken, testName, testId, testResults, propertyValu
                 postReferenceUpdate(csrfToken, testName, testId, testResults, result.id, null, projectSlug);
             },
             error: function(result) {
-                alert('error. log in console');
+                $.toast({
+                    type: 'danger',
+                    content: `Failed to create reference set.`
+                });
                 console.log(result);
             }
         });

--- a/dtf/static/dtf/results_table.js
+++ b/dtf/static/dtf/results_table.js
@@ -1,0 +1,176 @@
+
+function buildResultsTable(projectSlug, testId, results, references, canUpdate) {
+    let tableBody = $("#resultsTable").find('tbody');
+
+    results.forEach(function (result, resultIndex) {
+
+        let reference = references[result['name']];
+        if(reference === undefined || reference === null) {
+            reference = {value: null, source: null};
+        }
+
+        let row = $('<tr>')
+            .attr('class', 'filtered-row')
+            .attr('test-result-index', resultIndex)
+            .append($('<td>')
+                .attr('class', 'filter-status')
+                .append(renderStatusBadge(result['status']))
+            )
+            .append($('<td>')
+                .append($('<div>')
+                    .attr('class', 'd-flex')
+                    .append($('<span>')
+                        .text(result['name'])
+                    )
+                    .append($('<div>')
+                        .attr('class', 'ms-auto')
+                        .append($('<a>')
+                            .attr('class', 'btn btn-outline-dark dtf-btn-xs me-1')
+                            .attr('href', `/${projectSlug}/tests/${testId}/history?measurement_name=${result['name']}`)
+                            .append($('<i>')
+                                .attr('class', 'bi bi-graph-up')
+                            )
+                        )
+                    )
+                )
+            )
+            .append($('<td>')
+                .attr('id', 'tableDataValue')
+                .append(renderTestResultValue(projectSlug, result['value'], null))
+            )
+            .append($('<td>')
+                .attr('id', 'tableDataReferenceOnSubmission')
+                .append(renderTestResultValue(projectSlug, result['reference'], result['reference_source']))
+            )
+            .append($('<td>')
+                .attr('id', 'tableDataGlobalReference')
+                .append(renderTestResultValue(projectSlug, reference['value'], reference['source']))
+            )
+        if(canUpdate) {
+            row.append($('<td>')
+                .append($('<input>')
+                    .attr('id', 'updateReferenceCheckbox')
+                    .attr('class', 'form-check-input ms-2 me-2')
+                    .attr('type', 'checkbox')
+                    .attr('autocomplete', 'off')
+                )
+            )
+        }
+        tableBody.append(row);
+    });
+}
+
+function updateResultsTableReferences(projectSlug, testResults, references) {
+    let resultsRows = $('#resultsTable > tbody > tr');
+
+    resultsRows.each(function(index, tr) {
+        const testResultIndex = tr.getAttribute('test-result-index');
+        const testResult = testResults[testResultIndex];
+        let reference = references[testResult['name']];
+        if(reference === undefined || reference === null) {
+            reference = {value: null, source: null};
+        }
+
+        let globalReferenceData = $(tr).find('#tableDataGlobalReference').first();
+
+        globalReferenceData.empty();
+        globalReferenceData.append(renderTestResultValue(projectSlug, reference['value'], reference['source']));
+    });
+}
+
+function toggleAllBoxes(){
+    let toggleAllBox = $('#toggleAllReferencesCheckbox')[0];
+    let allBoxes = $('[id=updateReferenceCheckbox]');
+    for (var i = 0; i < allBoxes.length; i++) {
+        if (allBoxes[i].parentElement.parentElement.style.display == "none") {
+            continue;
+        }
+        allBoxes[i].checked = toggleAllBox.checked;
+    }
+}
+
+function uncheckAllBoxes(){
+    let toggleAllBox = $('#toggleAllReferencesCheckbox')[0];
+    toggleAllBox.checked = false;
+    let allBoxes = $('[id=updateReferenceCheckbox]');
+    for (var i = 0; i < allBoxes.length; i++) {
+        allBoxes[i].checked = false;
+    }
+}
+
+function postReferenceUpdate(csrfToken, testName, testId, testResults, referenceSetId, testReferenceId, projectSlug){
+    let data = {
+        "test_name": testName,
+        "default_source": testId,
+        "references": {
+        }
+    }
+
+    let resultsRows = $('#resultsTable > tbody > tr');
+
+    resultsRows.each(function(index, tr) {
+        let checkBox = $(tr).find('#updateReferenceCheckbox')[0];
+        if(checkBox.checked) {
+            const testResultIndex = tr.getAttribute('test-result-index');
+            const testResult = testResults[testResultIndex];
+            data["references"][testResult['name']]= {
+                "value": testResult['value']
+            };
+        }
+    });
+
+    if (testReferenceId === null) {
+        var url = `/api/projects/${projectSlug}/references/${referenceSetId}/tests`;
+        var method = "POST";
+    }
+    else {
+        var url = `/api/projects/${projectSlug}/references/${referenceSetId}/tests/${testReferenceId}`;
+        var method = "PATCH";
+    }
+    
+    let updatedCount = Object.keys(data["references"]).length;
+
+    $.ajax({
+        beforeSend: function(xhr, settings) {
+            xhr.setRequestHeader("X-CSRFToken", csrfToken);
+        },
+        type: method,
+        contentType: "application/json; charset=utf-8",
+        url: url,
+        data: JSON.stringify(data),
+        success: function(result) {
+            updateResultsTableReferences(projectSlug, testResults, result['references']);
+            uncheckAllBoxes();
+        },
+        error: function(result) {
+            console.log(result);
+        }
+    });
+}
+
+function updateReferences(csrfToken, testName, testId, testResults, propertyValues, referenceSetId, testReferenceId, projectSlug) {
+    if(referenceSetId === null) {
+        var data = {
+            "property_values" : propertyValues
+        };
+        $.ajax({
+            beforeSend: function(xhr, settings) {
+                xhr.setRequestHeader("X-CSRFToken", csrfToken);
+            },
+            type: 'POST',
+            contentType: "application/json; charset=utf-8",
+            url: `/api/projects/${projectSlug}/references`,
+            data: JSON.stringify(data),
+            success: function(result) {
+                postReferenceUpdate(csrfToken, testName, testId, testResults, result.id, null, projectSlug);
+            },
+            error: function(result) {
+                alert('error. log in console');
+                console.log(result);
+            }
+        });
+    }
+    else {
+        postReferenceUpdate(csrfToken, testName, testId, testResults, referenceSetId, testReferenceId, projectSlug)
+    }
+}

--- a/dtf/static/dtf/test_result_value.js
+++ b/dtf/static/dtf/test_result_value.js
@@ -1,0 +1,82 @@
+
+function renderTestResultValueData(value) {
+    if(value === undefined || value === null) {
+        return "N/A";
+    }
+    if(value.type === 'string') {
+        return value.data;
+    }
+    else if(value.type === 'integer') {
+        return value.data;
+    }
+    else if(value.type === 'float') {
+        return value.data;
+    }
+    else if(value.type === 'duration') {
+        return printISO8601Duration(parseISO8601Duration(value.data));
+    }
+    else if(value.type === 'list') {
+        // backward-compatibility. New data should use 'ndarray'
+        // TODO: implement this
+        return value.data;
+    }
+    else if(value.type === 'ndarray') {
+        const shape = value.data.shape;
+        const entries = value.data.entries.map(entry => renderTestResultValueData(entry));
+
+        const tensorOrder = shape.length;
+        const totalCount = shape.reduce((accumulator, currentValue) => accumulator + currentValue);
+
+        const inconsistent = totalCount != entries.length;
+
+        var out = [];
+
+        if(inconsistent || tensorOrder > 3) {
+            // Just print a 1D list of all available values
+            var size0 = len(entries)
+            var size1 = 1
+            var size2 = 1
+            const shapeStr = shape.join(',');
+            out.push(`Tensor-${tensorOrder} [${shapeStr}]:`);
+        }
+        else {
+            var size0 = tensorOrder >= 1 ? shape[0] : 1;
+            var size1 = tensorOrder >= 2 ? shape[1] : 1;
+            var size2 = tensorOrder >= 3 ? shape[2] : 1;
+        }
+
+        for(let k = 0; k < size2; k++) {
+            var currentTable = $('<table>').addClass('ndarray-value');
+            for(let i = 0; i < size0; i++) {
+                var currentRow = $('<tr>');
+                for(let j = 0; j < size1; j++) {
+                    const index = k*(size0*size1)+i*size1+j;
+                    currentRow.append($('<td>').append(entries[index]))
+                }
+                currentTable.append(currentRow)
+            }
+            out.push(currentTable);
+        }
+        return out;
+    }
+    else if(value.type === 'image') {
+        return $('<img>')
+            .attr('src', `data:image/png;base64, ${value.data}`)
+    }
+    else {
+        return value.data;
+    }
+}
+
+function renderTestResultValue(project_slug, value, source) {
+    valueHtml = renderTestResultValueData(value)
+
+    if(source === undefined || source === null) {
+        return valueHtml;
+    }
+    else {
+        return $('<a>')
+            .attr('href', `/${project_slug}/tests/${source}`)
+            .append(valueHtml);
+    }
+}

--- a/dtf/static/dtf/toast.js
+++ b/dtf/static/dtf/toast.js
@@ -1,0 +1,34 @@
+(function ($) {
+    let nextToastId = 1;
+
+    $.toast = function (options) {
+        let container = $('.toast-container');
+        if(container.Length == 0) {
+            return;
+        }
+
+        const type    = options.type;
+        const content = options.content;
+
+        let id = `toast-${nextToastId}`;
+        nextToastId++;
+
+        let html = '';
+        html = `<div id="${id}" class="toast align-items-center text-white bg-${type} border-0" role="alert" aria-live="assertive" aria-atomic="true">`;
+        html += `<div class="d-flex">
+                    <div class="toast-body">
+                        ${content}
+                    </div>
+                    <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+                </div>`;
+        html += `</div>`;
+
+        container.append(html);
+        let toast = container.find('.toast:last')
+
+        toast.toast('show');
+        container.on('hidden.bs.toast', '.toast', function () {
+            $(this).remove();
+        });
+    }
+}(jQuery));

--- a/dtf/templates/dtf/base.html
+++ b/dtf/templates/dtf/base.html
@@ -14,17 +14,12 @@
 
         <script src="{% static 'dtf/jquery.tablesorter.min.js' %}"></script>
 
-        <!-- Custom Css -->
         <link rel="stylesheet" type="text/css" href="{% static 'dtf/style.css' %}">
 
-        <!-- Custom Scripts -->
         <script src="{% static 'dtf/script.js' %}"></script>
-
-        <script src="{% static 'dtf/echarts.min.js' %}"></script>
 
         {% block head %}
         {% endblock %}
-
     </head>
 
     {% block body %}

--- a/dtf/templates/dtf/test_measurement_history.html
+++ b/dtf/templates/dtf/test_measurement_history.html
@@ -5,6 +5,9 @@
 
 {% block head %}
     <script src="{% static 'dtf/echarts.min.js' %}"></script>
+    <script src="{% static 'dtf/duration.js' %}"></script>
+    <script src="{% static 'dtf/badge.js' %}"></script>
+    <script src="{% static 'dtf/test_result_value.js' %}"></script>
 {% endblock %}
 
 {% block containertype %}fluid{% endblock %}
@@ -53,42 +56,6 @@
 <div id="histrory_chart" class="mt-3" style="height:500px;"></div>
 
 <script type="text/javascript">
-    const iso8601DurationRegex = /^(?<sign>[-+]?)P(?:(?<days>\d+(\.\d+)?)D)?(?:T(?:(?<hours>\d+(\.\d+)?)H)?(?:(?<minutes>\d+(\.\d+)?)M)?(?:(?<seconds>\d+(\.\d+)?)S)?)?$/u
-
-    parseISO8601Duration = function (iso8601DurationStr) {
-        var matches = iso8601DurationRegex.exec(iso8601DurationStr);
-
-        return {
-            sign: matches.groups.sign === undefined ? '+' : matches.groups.sign,
-            days: matches.groups.days === undefined ? 0 : parseFloat(matches.groups.days),
-            hours: matches.groups.hours === undefined ? 0 : parseFloat(matches.groups.hours),
-            minutes: matches.groups.minutes === undefined ? 0 : parseFloat(matches.groups.minutes),
-            seconds: matches.groups.seconds === undefined ? 0 : parseFloat(matches.groups.seconds)
-        };
-    };
-    totalSeconds = function (duration) {
-        return (duration.sign === '-' ? -1 : 1) *
-            (duration.days*24*60*60 +
-            duration.hours*60*60 +
-            duration.minutes*60 + 
-            duration.seconds);
-    };
-    statusToBadgeClass = {
-        successful: "text-success border-success",
-        unstable:   "text-warning border-warning",
-        failed:     "text-danger border-danger",
-        broken:     "text-danger border-danger",
-        unknown:    "text-secondary border-secondary",
-        skip:       "text-info border-info"
-    }
-    statusToIconClass = {
-        successful: "bi-check-circle-fill",
-        unstable:   "bi-exclamation-circle-fill",
-        failed:     "bi-x-circle-fill",
-        broken:     "bi-dash-circle-fill",
-        unknown:    "bi-question-circle-fill",
-        skip:       "bi-slash-circle-fill"
-    }
 
     extractValue = function (value) {
         if (value == null){
@@ -133,13 +100,7 @@
                             .attr('class', 'me-1')
                             .text('{{ measurement_name }} - status')
                         )
-                        .append($('<span>')
-                            .attr('class', 'ms-auto badge border ' + statusToBadgeClass[params[0].data[3]])
-                            .append($('<i>')
-                                .attr('class', 'bi ' + statusToIconClass[params[0].data[3]])
-                            )
-                            .append(" " + params[0].data[3])
-                        )
+                        .append(renderStatusBadge(params[0].data[3]).addClass('ms-auto'))
                     )
                 params.forEach(function (entry) {
                     result.append($('<div>')
@@ -267,15 +228,10 @@
                     const date = new Date(data['created']);
                     $('#test-created').text(date.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'medium', timeZone: '{{ display_timezone }}' }));
                     $('#test-status').empty()
-                        .append($('<span>')
-                            .attr('class', 'ms-auto badge border ' + statusToBadgeClass[data['status']])
-                            .append($('<i>')
-                                .attr('class', 'bi ' + statusToIconClass[data['status']])
-                            )
-                            .append(" " + data['status'])
-                        )
+                        .append(renderStatusBadge(data['status']));
                     const measurement = data['results'].find(element => element.name == '{{ measurement_name }}');
-                    $('#test-value').text(measurement['value']['data']);
+                    $('#test-value').empty()
+                        .append(renderTestResultValueData(measurement['value']));
                 },
                 error: function (jqXHR, textStatus, errorThrown) {
                     $('#test-created').removeClass("spinner-border spinner-border-sm text-secondary");
@@ -321,7 +277,8 @@
                     const date = new Date(data['created']);
                     $('#reference-created').text(date.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'medium', timeZone: '{{ display_timezone }}' }));
                     const measurement = data['results'].find(element => element.name == '{{ measurement_name }}');
-                    $('#reference-value').text(measurement['value']['data']);
+                    $('#reference-value').empty()
+                        .append(renderTestResultValueData(measurement['value']));
                 },
                 error: function (jqXHR, textStatus, errorThrown) {
                     $('#reference-created').removeClass("spinner-border spinner-border-sm text-secondary");

--- a/dtf/templates/dtf/test_measurement_history.html
+++ b/dtf/templates/dtf/test_measurement_history.html
@@ -1,6 +1,11 @@
 {% extends 'dtf/page_with_two_sidebars.html' %}
 
+{% load static %}
 {% load dtf.custom_filters %}
+
+{% block head %}
+    <script src="{% static 'dtf/echarts.min.js' %}"></script>
+{% endblock %}
 
 {% block containertype %}fluid{% endblock %}
 

--- a/dtf/templates/dtf/test_result_details.html
+++ b/dtf/templates/dtf/test_result_details.html
@@ -4,6 +4,7 @@
 {% load dtf.custom_filters %}
 
 {% block head %}
+    <script src="{% static 'dtf/toast.js' %}"></script>
     <script src="{% static 'dtf/duration.js' %}"></script>
     <script src="{% static 'dtf/badge.js' %}"></script>
     <script src="{% static 'dtf/test_result_value.js' %}"></script>
@@ -93,6 +94,9 @@ $('document').ready(function(){
 </div>
 
 <div class="bg-white pt-3 pb-1">
+
+<div id="toast-container" class="toast-container position-absolute content-wrapper p-3 top-0 start-50 translate-middle-x">
+</div>
 
 <div class="row">
     <div class="col">

--- a/dtf/templates/dtf/test_result_details.html
+++ b/dtf/templates/dtf/test_result_details.html
@@ -148,6 +148,18 @@ $('document').ready(function(){
     </tr>
     </thead>
     <tbody>
+    {% for i in placeholder_range %}
+        <tr class="placeholder-glow">
+            <td><span class="placeholder placeholder-lg w-100"></span></td>
+            <td><span class="placeholder placeholder-lg w-100"></span></td>
+            <td><span class="placeholder placeholder-lg w-100"></span></td>
+            <td><span class="placeholder placeholder-lg w-100"></span></td>
+            <td><span class="placeholder placeholder-lg w-100"></span></td>
+            {% if test_reference_permissions.add or test_reference_permissions.change %}
+            <td><span class="placeholder placeholder-lg w-100"></span></td>
+            {% endif %}
+        </tr>
+    {% endfor %}
     </tbody>
 </table>
 

--- a/dtf/templates/dtf/test_result_details.html
+++ b/dtf/templates/dtf/test_result_details.html
@@ -1,6 +1,14 @@
 {% extends 'dtf/page_with_two_sidebars.html' %}
 
+{% load static %}
 {% load dtf.custom_filters %}
+
+{% block head %}
+    <script src="{% static 'dtf/duration.js' %}"></script>
+    <script src="{% static 'dtf/badge.js' %}"></script>
+    <script src="{% static 'dtf/test_result_value.js' %}"></script>
+    <script src="{% static 'dtf/results_table.js' %}"></script>
+{% endblock %}
 
 {% block containertype %}fluid{% endblock %}
 
@@ -16,98 +24,45 @@
 
 <script>
 
-var all_data = {{ data | to_js_dict }};
+const initialTestResultsData =  {{ test_result.results | to_js_dict }};
+{% if test_reference is not None %}
+const initialTestReferencesData = {{ test_reference.references | to_js_dict }};
+{% else %}
+const initialTestReferencesData = {};
+{% endif %}
 
-function postReferenceUpdate(reference_set_id){
-    var data = {
-        "test_name":"{{ test_result.name }}",
-        "default_source":{{ test_result.id }},
-        "references":{
-        }
-    }
-
-    parameterBoxes = document.getElementsByClassName("parameterBox");
-    for (var i = 0; i < parameterBoxes.length; i++) {
-        box = parameterBoxes[i];
-        if (parameterBoxes[i].checked) {
-            if (box.getAttribute("pindex") === "") {
-                data["references"][box.getAttribute("id")]= {
-                    "value": null
-                };
-            }
-            else {
-                data["references"][box.getAttribute("id")] = {
-                    "value": all_data[box.getAttribute("pindex")]["test"]["value"]
-                };
-            }
-        }
-    }
-
-    {% if test_reference %}
-    var url = `/api/projects/{{ project.id }}/references/${reference_set_id}/tests/{{ test_reference.id }}`
-    var method = "PATCH"
-    {% else %}
-    var url = `/api/projects/{{ project.id }}/references/${reference_set_id}/tests`
-    var method = "POST"
-    {% endif %}
-
-    $.ajax({
-        beforeSend: function(xhr, settings) {
-            xhr.setRequestHeader("X-CSRFToken", "{{ csrf_token }}");
-        },
-        type: method,
-        contentType: "application/json; charset=utf-8",
-        url: url,
-        data: JSON.stringify(data),
-        success: function(result) {
-            location.reload();
-        },
-        error: function(result) {
-            alert('error. log in console');
-            console.log(result);
-        }
-    });
+function onReferenceUpdateButton() {
+    updateReferences(
+        "{{ csrf_token }}",
+        "{{ test_result.name }}",
+        {{ test_result.id }},
+        initialTestResultsData,
+        {{ property_values | to_js_dict }},
+        {% if reference_set is not None %}
+            {{ reference_set.id }},
+        {% else %}
+            null,
+        {% endif %}
+        {% if test_reference is not None %}
+            {{ test_reference.id }},
+        {% else %}
+            null,
+        {% endif %}
+        "{{ project.slug }}")
 }
 
-function updateReferences(){
-    {% if reference_set %}
-    // there is a reference set already
-    postReferenceUpdate({{ reference_set.id }})
-    {% else %}
-    // there is no reference set yet so we try to create one
-    var data = {
-        "property_values" : {{ property_values|safe }}
-    }
-    var reference_set_id = null
-    $.ajax({
-        beforeSend: function(xhr, settings) {
-            xhr.setRequestHeader("X-CSRFToken", "{{ csrf_token }}");
-        },
-        type: 'POST',
-        contentType: "application/json; charset=utf-8",
-        url: "/api/projects/{{ project.id }}/references",
-        data: JSON.stringify(data),
-        success: function(result) {
-            postReferenceUpdate(result.id)
-        },
-        error: function(result) {
-            alert('error. log in console');
-            console.log(result);
-        }
-    });
-    {% endif %}
-}
-
-function toggleAllBoxes(){
-    box = document.getElementById("allBox");
-    parameterBoxes = document.getElementsByClassName("parameterBox");
-    for (var i = 0; i < parameterBoxes.length; i++) {
-        if (parameterBoxes[i].parentElement.parentElement.style.display == "none") {
-            continue;
-        }
-        parameterBoxes[i].checked = box.checked;
-    }
-}
+$('document').ready(function(){
+    buildResultsTable(
+        "{{ test_result.submission.project.slug }}",
+        {{ test_result.id }},
+        initialTestResultsData,
+        initialTestReferencesData,
+        {% if test_reference_permissions.add or test_reference_permissions.change %}
+        true
+        {% else %}
+        false
+        {% endif %});
+});
 
 </script>
 
@@ -152,7 +107,7 @@ function toggleAllBoxes(){
 
     {% if test_reference_permissions.add or test_reference_permissions.change %}
     <div class="col-md-auto">
-        <button class="btn btn-sm btn-primary btn-lg active" onclick="updateReferences()">Update selected references</button>
+        <button class="btn btn-sm btn-primary btn-lg active" onclick="onReferenceUpdateButton()">Update selected references</button>
     </div>
     {% endif %}
 </div>
@@ -163,7 +118,7 @@ function toggleAllBoxes(){
 
 </div>
 
-<table class="table table-striped table-hover table-sm tablesorter">
+<table id="resultsTable" class="table table-striped table-hover table-sm tablesorter">
     <thead>
     <tr>
         <th class="noselect fit">
@@ -183,49 +138,12 @@ function toggleAllBoxes(){
         </th>
         {% if test_reference_permissions.add or test_reference_permissions.change %}
         <th class="noselect fit sorter-false">
-            <input class="ms-2 me-2" id="allBox" type="checkbox" onclick="toggleAllBoxes()" autocomplete="off"/>
+            <input class="form-check-input ms-2 me-2" id="toggleAllReferencesCheckbox" type="checkbox" onclick="toggleAllBoxes()" autocomplete="off"/>
         </th>
         {% endif %}
     </tr>
     </thead>
     <tbody>
-    {% for parameter in data %}
-        <tr class="filtered-row">
-            <td class="filter-status">
-                {{ parameter.status|status_badge }}
-            </td>
-            <td>
-                <div class="d-flex">
-                    <div class="">
-                        <span>{{ parameter.name }}</span>
-                    </div>
-                    {% if parameter.test.value is not None and parameter.test.value.type == 'duration' or parameter.test.value.type == 'integer' or parameter.test.value.type == 'float' %}
-                    <div class="ms-auto">
-                        <a class="btn btn-outline-dark dtf-btn-xs me-1" href="{% url 'test_measurement_history' test_result.submission.project.slug test_result.id %}?measurement_name={{ parameter.name|urlencode:"" }}"><i class="bi bi-graph-up"></i></a>
-                    </div>
-                    {% endif %}
-                </div>
-            </td>
-            <td>
-                {{ parameter.test|as_measurement_entry:test_result.submission.project }}
-            </td>
-            <td>
-                {{ parameter.reference_on_submission|as_measurement_entry:test_result.submission.project }}
-            </td>
-            <td>
-                {{ parameter.reference|as_measurement_entry:test_result.submission.project }}
-            </td>
-            {% if test_reference_permissions.add or test_reference_permissions.change %}
-            <td>
-                {% if parameter.test %}
-                    <input id="{{ parameter.name }}" class="ms-2 me-2 parameterBox" type="checkbox" pindex="{{ forloop.counter0 }}" autocomplete="off"/>
-                {% else %}
-                    <input id="{{ parameter.name }}" class="ms-2 me-2 parameterBox" type="checkbox" pindex="" autocomplete="off"/>
-                {% endif %}
-            </td>
-            {% endif %}
-        </tr>
-    {% endfor %}
     </tbody>
 </table>
 

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -317,6 +317,7 @@ class TestResultDetailView(ProjectViewMixin, ProjectPermissionRequiredMixin, gen
                                         test_reference=test_reference,
                                         test_result=test_result,
                                         property_values=property_values,
+                                        placeholder_range=range(10),
                                         #nav_data=nav_data,
                                         test_reference_permissions=get_model_permissions(self.request.user, project, TestReference))
 

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -17,7 +17,7 @@ from dtf.serializers import ProjectSubmissionPropertySerializer
 from dtf.serializers import WebhookSerializer
 
 from dtf.models import TestResult, Membership, Project, ReferenceSet, TestReference, Submission, ProjectSubmissionProperty, Webhook, WebhookLogEntry
-from dtf.functions import create_view_data_from_test_references, create_reference_query
+from dtf.functions import create_reference_query
 from dtf.forms import NewProjectForm, ProjectSettingsForm, ProjectSubmissionPropertyForm, MembershipForm, WebhookForm, NewUserForm, LoginForm, ResetPasswordForm, PasswordSetForm
 from dtf.permissions import ProjectPermissionRequiredMixin, has_required_model_role, get_model_permissions, check_required_model_role
 
@@ -310,21 +310,14 @@ class TestResultDetailView(ProjectViewMixin, ProjectPermissionRequiredMixin, gen
                     if not prop_value is None:
                         property_values[prop.name] = prop_value
 
-        if test_reference is not None:
-            references = test_reference.references
-        else:
-            references = {}
-
-        data = create_view_data_from_test_references(test_result.results, references)
         # nav_data = project.get_nav_data(test_result.name, test_result.submission.id)
         return super().get_context_data(**kwargs,
                                         project=project,
                                         reference_set=reference_set,
                                         test_reference=test_reference,
                                         test_result=test_result,
-                                        property_values=str(property_values),
+                                        property_values=property_values,
                                         #nav_data=nav_data,
-                                        data=data,
                                         test_reference_permissions=get_model_permissions(self.request.user, project, TestReference))
 
 class SubmissionDetailView(ProjectViewMixin, ProjectPermissionRequiredMixin, generic.DetailView):


### PR DESCRIPTION
This PR moves the generation of the test results table from using Django templates to the client side in JavaScript. This allows to update the table entries after a reference update on the client side without requiring a page reload.

To this end some additional utility functions have been introduced in JavaScript (e.g. to create HTML for badges or test results). Currently that code exists two times: once in Python and once in JavaScript. This should be changed in a future MR and the HTML should be created everywhere consistently by the JavaScript code.

Not requiring a page reload on reference updates allows to use bootstrap toast notifications to inform the user on successful/failed reference updates.

Resolves #29

Works towards fixing #60 and #61