### PR TITLE
Add curl command examples for PowerShell

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,8 @@ author = 'Christopher Voss'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'sphinx_tabs.tabs',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/modules/api/generated/projects/projects-GET-curl.ps1
+++ b/docs/modules/api/generated/projects/projects-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects

--- a/docs/modules/api/generated/projects/projects-POST-curl.ps1
+++ b/docs/modules/api/generated/projects/projects-POST-curl.ps1
@@ -1,0 +1,7 @@
+curl -X POST `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""name"": ""My Test Project"",
+             ""slug"": ""my-test-project""
+         }' `
+  http://dtf.example.com/api/projects

--- a/docs/modules/api/generated/projects/projects_id-DELETE-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id-DELETE-curl.ps1
@@ -1,0 +1,2 @@
+curl -X DELETE `
+  http://dtf.example.com/api/projects/1

--- a/docs/modules/api/generated/projects/projects_id-GET-primary_key-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id-GET-primary_key-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1

--- a/docs/modules/api/generated/projects/projects_id-GET-slug-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id-GET-slug-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/demo

--- a/docs/modules/api/generated/projects/projects_id-PUT-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id-PUT-curl.ps1
@@ -1,0 +1,7 @@
+curl -X PUT `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""name"": ""Demo Project New Name"",
+             ""slug"": ""demo-project""
+         }' `
+  http://dtf.example.com/api/projects/1

--- a/docs/modules/api/generated/projects/projects_id_members-GET-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_members-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/members

--- a/docs/modules/api/generated/projects/projects_id_members-POST-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_members-POST-curl.ps1
@@ -1,0 +1,7 @@
+curl -X POST `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""user"": 1,
+             ""role"": ""developer""
+         }' `
+  http://dtf.example.com/api/projects/1/members

--- a/docs/modules/api/generated/projects/projects_id_members_id-DELETE-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_members_id-DELETE-curl.ps1
@@ -1,0 +1,2 @@
+curl -X DELETE `
+  http://dtf.example.com/api/projects/1/members/1

--- a/docs/modules/api/generated/projects/projects_id_members_id-GET-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_members_id-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/members/1

--- a/docs/modules/api/generated/projects/projects_id_members_id-PUT-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_members_id-PUT-curl.ps1
@@ -1,0 +1,8 @@
+curl -X PUT `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""project"": 1,
+             ""user"": 2,
+             ""role"": ""developer""
+         }' `
+  http://dtf.example.com/api/projects/1/members/1

--- a/docs/modules/api/generated/projects/projects_id_properties-GET-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_properties-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/properties

--- a/docs/modules/api/generated/projects/projects_id_properties-POST-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_properties-POST-curl.ps1
@@ -1,0 +1,11 @@
+curl -X POST `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""name"": ""Property Name"",
+             ""required"": false,
+             ""display"": true,
+             ""display_as_link"": false,
+             ""display_replace"": ""Value is {VALUE}"",
+             ""influence_reference"": false
+         }' `
+  http://dtf.example.com/api/projects/1/properties

--- a/docs/modules/api/generated/projects/projects_id_properties_id-DELETE-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_properties_id-DELETE-curl.ps1
@@ -1,0 +1,2 @@
+curl -X DELETE `
+  http://dtf.example.com/api/projects/1/properties/1

--- a/docs/modules/api/generated/projects/projects_id_properties_id-GET-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_properties_id-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/properties/1

--- a/docs/modules/api/generated/projects/projects_id_properties_id-PUT-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_properties_id-PUT-curl.ps1
@@ -1,0 +1,12 @@
+curl -X PUT `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""project"": 1,
+             ""name"": ""Branch"",
+             ""required"": false,
+             ""display"": false,
+             ""display_as_link"": false,
+             ""display_replace"": """",
+             ""influence_reference"": false
+         }' `
+  http://dtf.example.com/api/projects/1/properties/1

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id_history-GET-limited-curl.ps1
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id_history-GET-limited-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/submissions/1/tests/1/history?measurement_name=runtime&limit=2

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id_history-GET-unlimited-curl.ps1
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id_history-GET-unlimited-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/submissions/1/tests/1/history?measurement_name=runtime

--- a/docs/modules/api/generated/test_results/projects_id_tests-GET-curl.ps1
+++ b/docs/modules/api/generated/test_results/projects_id_tests-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/tests

--- a/docs/modules/api/generated/test_results/projects_id_tests_id-DELETE-curl.ps1
+++ b/docs/modules/api/generated/test_results/projects_id_tests_id-DELETE-curl.ps1
@@ -1,0 +1,2 @@
+curl -X DELETE `
+  http://dtf.example.com/api/projects/1/tests/1

--- a/docs/modules/api/generated/test_results/projects_id_tests_id-GET-curl.ps1
+++ b/docs/modules/api/generated/test_results/projects_id_tests_id-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/tests/1

--- a/docs/modules/api/generated/test_results/projects_id_tests_id-PUT-curl.ps1
+++ b/docs/modules/api/generated/test_results/projects_id_tests_id-PUT-curl.ps1
@@ -1,0 +1,64 @@
+curl -X PUT `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""submission"": 1,
+             ""name"": ""demo (np=1)"",
+             ""status"": ""failed"",
+             ""results"": [
+                 {
+                     ""name"": ""runtime"",
+                     ""value"": {
+                         ""data"": ""PT0.124356S"",
+                         ""type"": ""duration""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 },
+                 {
+                     ""name"": ""residual[0]"",
+                     ""value"": {
+                         ""data"": 2.345,
+                         ""type"": ""float""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 },
+                 {
+                     ""name"": ""integer[0]"",
+                     ""value"": {
+                         ""data"": 98,
+                         ""type"": ""integer""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 },
+                 {
+                     ""name"": ""algorithm-time[0]"",
+                     ""value"": {
+                         ""data"": ""PT0.345000S"",
+                         ""type"": ""duration""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 },
+                 {
+                     ""name"": ""argument[0]"",
+                     ""value"": {
+                         ""data"": ""process argument 1"",
+                         ""type"": ""string""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 },
+                 {
+                     ""name"": ""screenshot-image.png"",
+                     ""value"": {
+                         ""data"": ""iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII="",
+                         ""type"": ""image""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 }
+             ]
+         }' `
+  http://dtf.example.com/api/projects/1/tests/1

--- a/docs/modules/api/generated/users/users-GET-curl.ps1
+++ b/docs/modules/api/generated/users/users-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/users

--- a/docs/modules/api/generated/users/users_id-GET-curl.ps1
+++ b/docs/modules/api/generated/users/users_id-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/users/2

--- a/docs/modules/api/projects.rst
+++ b/docs/modules/api/projects.rst
@@ -12,9 +12,17 @@ List all projects available on the server.
 
 An example could look as follows:
 
+.. tabs::
 
-.. literalinclude :: generated/projects/projects-GET-curl.sh
-   :language: bash
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects-GET-curl.ps1
+         :language: PowerShell
 
 which might give a result like this:
 
@@ -37,8 +45,17 @@ Create a new, global project on the server.
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects-POST-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects-POST-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects-POST-curl.ps1
+         :language: PowerShell
 
 which might give a result like this:
 
@@ -61,13 +78,31 @@ Retrieve a specific project from the server.
 
 An example using the id could look as follows:
 
-.. literalinclude :: generated/projects/projects_id-GET-primary_key-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id-GET-primary_key-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id-GET-primary_key-curl.ps1
+         :language: PowerShell
 
 or using the project slug:
 
-.. literalinclude :: generated/projects/projects_id-GET-slug-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id-GET-slug-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id-GET-slug-curl.ps1
+         :language: PowerShell
 
 which might give a result like this:
 
@@ -90,8 +125,17 @@ Modify the fields of an existing project. All fields have to be given (even the 
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects_id-PUT-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id-PUT-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id-PUT-curl.ps1
+         :language: PowerShell
 
 which might give a result like this:
 
@@ -114,8 +158,17 @@ Deletes a project and all associated data. This can not be undone!
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects_id-DELETE-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id-DELETE-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id-DELETE-curl.ps1
+         :language: PowerShell
 
 .. _api-projects-properties-list:
 
@@ -133,8 +186,17 @@ List all properties of a given project.
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects_id_properties-GET-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_properties-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_properties-GET-curl.ps1
+         :language: PowerShell
 
 which might give a result like this:
 
@@ -157,8 +219,17 @@ Add a new property to a project.
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects_id_properties-POST-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_properties-POST-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_properties-POST-curl.ps1
+         :language: PowerShell
 
 which might give a result like this:
 
@@ -182,8 +253,17 @@ Retrieve a specific property from a project.
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects_id_properties_id-GET-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_properties_id-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_properties_id-GET-curl.ps1
+         :language: PowerShell
 
 which might give a result like this:
 
@@ -206,8 +286,17 @@ Modify the fields of an existing properties. All fields have to be given (even t
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects_id_properties_id-PUT-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_properties_id-PUT-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_properties_id-PUT-curl.ps1
+         :language: PowerShell
 
 which might give a result like this:
 
@@ -230,8 +319,17 @@ Deletes a property from a project. This can not be undone!
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects_id_properties_id-DELETE-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_properties_id-DELETE-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_properties_id-DELETE-curl.ps1
+         :language: PowerShell
 
 List project members
 --------------------
@@ -247,8 +345,17 @@ List all members of a given project.
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects_id_members-GET-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_members-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_members-GET-curl.ps1
+         :language: PowerShell
 
 which might give a result like this:
 
@@ -271,8 +378,17 @@ Add a new member to a project.
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects_id_members-POST-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_members-POST-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_members-POST-curl.ps1
+         :language: PowerShell
 
 which might give a result like this:
 
@@ -296,8 +412,17 @@ Retrieve a specific member from a project.
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects_id_members_id-GET-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_members_id-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_members_id-GET-curl.ps1
+         :language: PowerShell
 
 which might give a result like this:
 
@@ -320,8 +445,17 @@ Modify the fields of an existing members. All fields have to be given (even the 
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects_id_members_id-PUT-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_members_id-PUT-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_members_id-PUT-curl.ps1
+         :language: PowerShell
 
 which might give a result like this:
 
@@ -344,7 +478,16 @@ Deletes a member from a project. This can not be undone!
 
 An example could look as follows:
 
-.. literalinclude :: generated/projects/projects_id_members_id-DELETE-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_members_id-DELETE-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_members_id-DELETE-curl.ps1
+         :language: PowerShell
 
 .. _api-projects-members-list:

--- a/docs/modules/api/test_results.rst
+++ b/docs/modules/api/test_results.rst
@@ -17,8 +17,17 @@ List all test results from all submissions of a given project.
 
 An example could look as follows:
 
-.. literalinclude :: generated/test_results/projects_id_tests-GET-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_results/projects_id_tests-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_results/projects_id_tests-GET-curl.ps1
+         :language: powershell
 
 which might give a result like this:
 
@@ -42,8 +51,17 @@ Retrieve a specific test result from a project.
 
 An example could look as follows:
 
-.. literalinclude :: generated/test_results/projects_id_tests_id-GET-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_results/projects_id_tests_id-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_results/projects_id_tests_id-GET-curl.ps1
+         :language: powershell
 
 which might give a result like this:
 
@@ -66,8 +84,17 @@ Modify the fields of an existing test result. All fields have to be given (even 
 
 An example could look as follows:
 
-.. literalinclude :: generated/test_results/projects_id_tests_id-PUT-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_results/projects_id_tests_id-PUT-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_results/projects_id_tests_id-PUT-curl.ps1
+         :language: powershell
 
 which might give a result like this:
 
@@ -90,8 +117,17 @@ Deletes a test result from a project. This can not be undone!
 
 An example could look as follows:
 
-.. literalinclude :: generated/test_results/projects_id_tests_id-DELETE-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_results/projects_id_tests_id-DELETE-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_results/projects_id_tests_id-DELETE-curl.ps1
+         :language: powershell
 
 
 .. _api-test_results-history:
@@ -112,8 +148,17 @@ which has the same *reference relevant properties* as the submission the current
 
 An example could look as follows:
 
-.. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id_history-GET-limited-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id_history-GET-limited-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id_history-GET-limited-curl.ps1
+         :language: powershell
 
 which might give a result like this:
 

--- a/docs/modules/api/users.rst
+++ b/docs/modules/api/users.rst
@@ -13,8 +13,17 @@ List all users available on the server.
 An example could look as follows:
 
 
-.. literalinclude :: generated/users/users-GET-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/users/users-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/users/users-GET-curl.ps1
+         :language: powershell
 
 which might give a result like this:
 
@@ -38,8 +47,17 @@ Retrieve a specific user from the server.
 
 An example could look as follows:
 
-.. literalinclude :: generated/users/users_id-GET-curl.sh
-   :language: bash
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/users/users_id-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/users/users_id-GET-curl.ps1
+         :language: powershell
 
 which might give a result like this:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ djangorestframework
 jsonschema
 sphinx
 sphinx_hand_theme
+sphinx_tabs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ jsonschema
 sphinx
 sphinx_hand_theme
 sphinx_tabs
+pygments>=2.9


### PR DESCRIPTION
This MR adds PowerShell versions of the `curl` command examples in the API documentation.
The PowerShell commands are autogenerated just like the bash commands and do include only minor differences (using `` ` `` as line continuation character instead of `\` and using double quotes `""` within the JSON data to be send) compared to the bash commands.

To display the PowerShell examples we do use the [sphinx-tabs](https://sphinx-tabs.readthedocs.io) extension.