### PR TITLE
More API documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,15 +50,12 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_hand_theme'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
-import sphinx_hand_theme
-
-html_theme_path = [sphinx_hand_theme.get_html_theme_path()]
+# html_static_path = ['_static']
 
 # https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html
 html_theme_options = {

--- a/docs/modules/api.rst
+++ b/docs/modules/api.rst
@@ -67,6 +67,8 @@ API Overview
 
 :doc:`References <api/references>`
 
+:doc:`Test References <api/test_references>`
+
 :doc:`Users <api/users>`
 
 .. toctree::
@@ -76,4 +78,5 @@ API Overview
    api/submissions
    api/test_results
    api/references
+   api/test_references
    api/users

--- a/docs/modules/api/endpoints/projects/projects_id_webhooks-GET.json
+++ b/docs/modules/api/endpoints/projects/projects_id_webhooks-GET.json
@@ -1,0 +1,18 @@
+{
+    "endpoint": "/projects/:project_id/webhooks",
+    "method": "GET",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project to get the webhooks of."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/projects/projects_id_webhooks-POST.json
+++ b/docs/modules/api/endpoints/projects/projects_id_webhooks-POST.json
@@ -1,0 +1,67 @@
+
+{
+    "endpoint": "/projects/:project_id/webhooks",
+    "method": "POST",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project to add the new webhook to."
+        },
+        "name" : {
+            "type": "string",
+            "required": true,
+            "description": "The name of the new webhook."
+        },
+        "url" : {
+            "type": "url",
+            "required": true,
+            "description": "The URL to be triggered by the webhook."
+        },
+        "secret_token" : {
+            "type": "string",
+            "required": true,
+            "description": [
+                "This is send in the request header as `X-DTF-Token` and",
+                "should be used by the client to authenticate the payload."
+            ]
+        },
+        "on_submission" : {
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "description": "Trigger when a submission is created, modified or deleted."
+        },
+        "on_test_result" : {
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "description": "Trigger when test results for a submission are created, modified or deleted."
+        },
+        "on_reference_set" : {
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "description": "Trigger when a reference set is created, modified or deleted."
+        },
+        "on_test_reference" : {
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "description": "Trigger when test references are created, modified or deleted."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1
+            },
+            "data": {
+                "name" : "My Webhook",
+                "url" : "http://example.com/my/hook/path",
+                "secret_token" : "sMeyqOYenB8Czi2zGOFHNg",
+                "on_submission" : false
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/projects/projects_id_webhooks_id-DELETE.json
+++ b/docs/modules/api/endpoints/projects/projects_id_webhooks_id-DELETE.json
@@ -1,0 +1,24 @@
+{
+    "endpoint": "/projects/:project_id/webhooks/:webhook_id",
+    "method": "DELETE",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":webhook_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the webhook to delete."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "webhook_id": 2
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/projects/projects_id_webhooks_id-GET.json
+++ b/docs/modules/api/endpoints/projects/projects_id_webhooks_id-GET.json
@@ -1,0 +1,24 @@
+{
+    "endpoint": "/projects/:project_id/webhooks/:webhook_id",
+    "method": "GET",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":webhook_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the webhook to get."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "webhook_id": 1
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/projects/projects_id_webhooks_id-PUT.json
+++ b/docs/modules/api/endpoints/projects/projects_id_webhooks_id-PUT.json
@@ -1,0 +1,77 @@
+{
+    "endpoint": "/projects/:project_id/webhooks/:webhook_id",
+    "method": "PUT",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":webhook_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the webhook to modify."
+        },
+        "name" : {
+            "type": "string",
+            "required": true,
+            "description": "The new name of the webhook."
+        },
+        "url" : {
+            "type": "url",
+            "required": true,
+            "description": "The new URL to be triggered by the webhook."
+        },
+        "secret_token" : {
+            "type": "string",
+            "required": true,
+            "description": [
+                "This is send in the request header as `X-DTF-Token` and",
+                "should be used by the client to authenticate the payload."
+            ]
+        },
+        "on_submission" : {
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "description": "Trigger when a submission is created, modified or deleted."
+        },
+        "on_test_result" : {
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "description": "Trigger when test results for a submission are created, modified or deleted."
+        },
+        "on_reference_set" : {
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "description": "Trigger when a reference set is created, modified or deleted."
+        },
+        "on_test_reference" : {
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "description": "Trigger when test references are created, modified or deleted."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "webhook_id": 1
+            },
+            "data": {
+                "project": 1,
+                "id": 1,
+                "name": "Demo Bot",
+                "url": "http://129.26.133.164:8666/references/demo",
+                "secret_token": "58a61681-f3c0-4d0f-a8bf-c87193f2603d",
+                "on_submission": true,
+                "on_test_result": false,
+                "on_reference_set": false,
+                "on_test_reference": true
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/projects/projects_id_webhooks_id_logs-GET.json
+++ b/docs/modules/api/endpoints/projects/projects_id_webhooks_id_logs-GET.json
@@ -1,0 +1,24 @@
+{
+    "endpoint": "/projects/:project_id/webhooks/:webhook_id/logs",
+    "method": "GET",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":webhook_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the webhook which's logs to retrieve."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "webhook_id": 1
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/references/projects_id_references-GET.json
+++ b/docs/modules/api/endpoints/references/projects_id_references-GET.json
@@ -1,0 +1,18 @@
+{
+    "endpoint": "/projects/:project_id/references",
+    "method": "GET",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project to get the reference sets of."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/references/projects_id_references-POST.json
+++ b/docs/modules/api/endpoints/references/projects_id_references-POST.json
@@ -1,0 +1,33 @@
+{
+    "endpoint": "/projects/:project_id/references",
+    "method": "POST",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project to add the new reference set to."
+        },
+        "property_values" : {
+            "type": "json",
+            "required": false,
+            "default": "{}",
+            "description": [
+                "Property value pairs for the reference set.",
+                "These have to match the properties specified in the project."
+            ]
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1
+            },
+            "data": {
+                "property_values": {
+                    "Hostname": "Vasa",
+                    "Branch": "feature"
+                }
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/references/projects_id_references_id-DELETE.json
+++ b/docs/modules/api/endpoints/references/projects_id_references_id-DELETE.json
@@ -1,0 +1,24 @@
+{
+    "endpoint": "/projects/:project_id/references/:reference_id",
+    "method": "DELETE",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":reference_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the reference set to delete."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "reference_id": 2
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/references/projects_id_references_id-GET.json
+++ b/docs/modules/api/endpoints/references/projects_id_references_id-GET.json
@@ -1,0 +1,24 @@
+{
+    "endpoint": "/projects/:project_id/references/:reference_id",
+    "method": "GET",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":reference_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the reference set to get."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "reference_id": 1
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/references/projects_id_references_id-PUT.json
+++ b/docs/modules/api/endpoints/references/projects_id_references_id-PUT.json
@@ -1,0 +1,40 @@
+{
+    "endpoint": "/projects/:project_id/references/:reference_id",
+    "method": "PUT",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":reference_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the reference set to modify."
+        },
+        "property_values" : {
+            "type": "json",
+            "required": false,
+            "default": "{}",
+            "description": [
+                "Property name-value pairs for the reference set.",
+                "These have to match the properties specified in the project."
+            ]
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "reference_id": 1
+            },
+            "data": {
+                "project": 1,
+                "property_values": {
+                    "Hostname": "Vasa",
+                    "Branch": "main"
+                }
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/submissions/projects_id_submissions-GET.json
+++ b/docs/modules/api/endpoints/submissions/projects_id_submissions-GET.json
@@ -1,0 +1,18 @@
+{
+    "endpoint": "/projects/:project_id/submissions",
+    "method": "GET",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project to get the submissions of."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/submissions/projects_id_submissions-POST.json
+++ b/docs/modules/api/endpoints/submissions/projects_id_submissions-POST.json
@@ -1,0 +1,33 @@
+{
+    "endpoint": "/projects/:project_id/submissions",
+    "method": "POST",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project to add the new submission to."
+        },
+        "info" : {
+            "type": "json",
+            "required": false,
+            "default": "{}",
+            "description": [
+                "Property value pairs for the submission.",
+                "These have to match the properties specified in the project."
+            ]
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1
+            },
+            "data": {
+                "info": {
+                    "Hostname": "Vasa",
+                    "Branch": "feature"
+                }
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/submissions/projects_id_submissions_id-DELETE.json
+++ b/docs/modules/api/endpoints/submissions/projects_id_submissions_id-DELETE.json
@@ -1,0 +1,24 @@
+{
+    "endpoint": "/projects/:project_id/submissions/:submission_id",
+    "method": "DELETE",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":submission_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the submission to delete."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "submission_id": 3
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/submissions/projects_id_submissions_id-GET.json
+++ b/docs/modules/api/endpoints/submissions/projects_id_submissions_id-GET.json
@@ -1,0 +1,24 @@
+{
+    "endpoint": "/projects/:project_id/submissions/:submission_id",
+    "method": "GET",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":submission_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the submission to get."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "submission_id": 1
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/submissions/projects_id_submissions_id-PUT.json
+++ b/docs/modules/api/endpoints/submissions/projects_id_submissions_id-PUT.json
@@ -1,0 +1,40 @@
+{
+    "endpoint": "/projects/:project_id/submissions/:submission_id",
+    "method": "PUT",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":submission_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the submission to modify."
+        },
+        "info" : {
+            "type": "json",
+            "required": false,
+            "default": "{}",
+            "description": [
+                "Property name-value pairs for the submission.",
+                "These have to match the properties specified in the project."
+            ]
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "submission_id": 2
+            },
+            "data": {
+                "project": 1,
+                "info": {
+                    "Hostname": "Vasa",
+                    "Branch": "feature"
+                }
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/test_references/projects_id_references_id_tests-GET.json
+++ b/docs/modules/api/endpoints/test_references/projects_id_references_id_tests-GET.json
@@ -1,0 +1,24 @@
+{
+    "endpoint": "/projects/:project_id/references/:reference_id/tests",
+    "method": "GET",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project to get the test references of."
+        },
+        ":reference_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the reference set to get the tests references of."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "reference_id": 1
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/test_references/projects_id_references_id_tests-POST.json
+++ b/docs/modules/api/endpoints/test_references/projects_id_references_id_tests-POST.json
@@ -1,0 +1,58 @@
+{
+    "endpoint": "/projects/:project_id/references/:reference_id/tests",
+    "method": "POST",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project of the reference set to create the new test reference for."
+        },
+        ":reference_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the reference set to create a new test reference for."
+        },
+        "test_name" : {
+            "type": "string",
+            "required": true,
+            "description": "The name of the test the new references are for."
+        },
+        "default_source" : {
+            "type": "integer",
+            "required": false,
+            "description": "The id of the submission which is used as default source for references that do not have an explicit source given."
+        },
+        "references" : {
+            "type": "json",
+            "required": true,
+            "description": "Test result references. TODO: add JSON schema"
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "reference_id": 1
+            },
+            "data": {
+                "test_name" : "New Test",
+                "default_source" : 2,
+                "references" : {
+                    "runtime" : {
+                        "value": {
+                            "data": "PT0.124356S",
+                            "type": "duration"
+                        },
+                        "source" : 1
+                    },
+                    "Result1" : {
+                        "value" : {
+                            "data": 123,
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/test_references/projects_id_references_id_tests_id-DELETE.json
+++ b/docs/modules/api/endpoints/test_references/projects_id_references_id_tests_id-DELETE.json
@@ -1,0 +1,30 @@
+{
+    "endpoint": "/projects/:project_id/references/:reference_id/tests/:test_id",
+    "method": "DELETE",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":reference_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the reference set."
+        },
+        ":test_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the test references to delete."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "reference_id" : 1,
+                "test_id": 2
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/test_references/projects_id_references_id_tests_id-GET.json
+++ b/docs/modules/api/endpoints/test_references/projects_id_references_id_tests_id-GET.json
@@ -1,0 +1,30 @@
+{
+    "endpoint": "/projects/:project_id/references/:reference_id/tests/:test_id",
+    "method": "GET",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":reference_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the reference set."
+        },
+        ":test_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the test references to get."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "reference_id" : 1,
+                "test_id": 1
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/test_references/projects_id_references_id_tests_id-PUT.json
+++ b/docs/modules/api/endpoints/test_references/projects_id_references_id_tests_id-PUT.json
@@ -1,0 +1,81 @@
+{
+    "endpoint": "/projects/:project_id/references/:reference_id/tests/:test_id",
+    "method": "PUT",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":reference_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the reference set."
+        },
+        ":test_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the test references to modify."
+        },
+        "test_name" : {
+            "type": "string",
+            "required": true,
+            "description": "The name of the test the references are for."
+        },
+        "references" : {
+            "type": "json",
+            "required": true,
+            "description": "Test references. TODO: add JSON schema"
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "reference_id" : 1,
+                "test_id": 1
+            },
+            "data": {
+                "reference_set": 1,
+                "test_name": "demo (np=1)",
+                "references": {
+                    "runtime": {
+                        "value": {
+                            "data": "PT0.124356S",
+                            "type": "duration"
+                        },
+                        "source": 1
+                    },
+                    "residual[0]": {
+                        "value": {
+                            "data": 2.345,
+                            "type": "float"
+                        },
+                        "source": 1
+                    },
+                    "integer[0]": {
+                        "value": {
+                            "data": 98,
+                            "type": "integer"
+                        },
+                        "source": 1
+                    },
+                    "algorithm-time[0]": {
+                        "value": {
+                            "data": "PT0.345000S",
+                            "type": "duration"
+                        },
+                        "source": 1
+                    },
+                    "argument[0]": {
+                        "value": {
+                            "data": "process argument 1",
+                            "type": "string"
+                        },
+                        "source": 1
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/test_results/projects_id_submissions_id_tests-GET.json
+++ b/docs/modules/api/endpoints/test_results/projects_id_submissions_id_tests-GET.json
@@ -1,0 +1,24 @@
+{
+    "endpoint": "/projects/:project_id/submissions/:submission_id/tests",
+    "method": "GET",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project to get the test results of."
+        },
+        ":submission_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the submission to get."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "submission_id": 1
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/test_results/projects_id_submissions_id_tests-POST.json
+++ b/docs/modules/api/endpoints/test_results/projects_id_submissions_id_tests-POST.json
@@ -1,0 +1,59 @@
+{
+    "endpoint": "/projects/:project_id/submissions/:submission_id/tests",
+    "method": "POST",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project of the submission to create the new test for."
+        },
+        ":submission_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the submission to create a new test for."
+        },
+        "name" : {
+            "type": "string",
+            "required": true,
+            "description": "The name of the new test."
+        },
+        "results" : {
+            "type": "json",
+            "required": false,
+            "description": "Test results. TODO: add JSON schema"
+        }
+    },
+    "examples" : [
+        {
+            "name" : "empty",
+            "arguments" : {
+                "project_id" : 1,
+                "submission_id": 1
+            },
+            "data": {
+                "name" : "New Empty Test"
+            }
+        },
+        {
+            "name" : "nonempty",
+            "arguments" : {
+                "project_id" : 1,
+                "submission_id": 1
+            },
+            "data": {
+                "name" : "New Test",
+                "results" : [
+                    {
+                        "name": "runtime",
+                        "value": {
+                            "data": "PT0.124356S",
+                            "type": "duration"
+                        },
+                        "status": "unknown",
+                        "reference": null
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/test_results/projects_id_submissions_id_tests_id-DELETE.json
+++ b/docs/modules/api/endpoints/test_results/projects_id_submissions_id_tests_id-DELETE.json
@@ -1,0 +1,25 @@
+{
+    "endpoint": "/projects/:project_id/submissions/:submission_id/tests/:test_id",
+    "method": "DELETE",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":test_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the test results to delete."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "submission_id" : 2,
+                "test_id": 2
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/test_results/projects_id_submissions_id_tests_id-GET.json
+++ b/docs/modules/api/endpoints/test_results/projects_id_submissions_id_tests_id-GET.json
@@ -1,0 +1,25 @@
+{
+    "endpoint": "/projects/:project_id/submissions/:submission_id/tests/:test_id",
+    "method": "GET",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":test_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the test results to get."
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "submission_id" : 1,
+                "test_id": 1
+            }
+        }
+    ]
+}

--- a/docs/modules/api/endpoints/test_results/projects_id_submissions_id_tests_id-PUT.json
+++ b/docs/modules/api/endpoints/test_results/projects_id_submissions_id_tests_id-PUT.json
@@ -1,0 +1,101 @@
+{
+    "endpoint": "/projects/:project_id/submissions/:submission_id/tests/:test_id",
+    "method": "PUT",
+    "attributes" : {
+        ":project_id" : {
+            "type": "string/integer",
+            "required": true,
+            "description": "The id or slug of the project."
+        },
+        ":test_id" : {
+            "type": "integer",
+            "required": true,
+            "description": "The id of the test results to modify."
+        },
+        "name" : {
+            "type": "string",
+            "required": true,
+            "description": "The new name of the test."
+        },
+        "status" : {
+            "type": "string",
+            "required": true,
+            "description": "Status of the test. Allowed values are 'skip', 'successful', 'unstable', 'unknown', 'failed', or 'broken'."
+        },
+        "results" : {
+            "type": "json",
+            "required": true,
+            "description": "Test results. TODO: add JSON schema"
+        }
+    },
+    "examples" : [
+        {
+            "arguments" : {
+                "project_id" : 1,
+                "submission_id" : 1,
+                "test_id": 1
+            },
+            "data": {
+                "submission" : 1,
+                "name" : "demo (np=1)",
+                "status" : "failed",
+                "results": [
+                    {
+                        "name": "runtime",
+                        "value": {
+                            "data": "PT0.124356S",
+                            "type": "duration"
+                        },
+                        "status": "unknown",
+                        "reference": null
+                    },
+                    {
+                        "name": "residual[0]",
+                        "value": {
+                            "data": 2.345,
+                            "type": "float"
+                        },
+                        "status": "unknown",
+                        "reference": null
+                    },
+                    {
+                        "name": "integer[0]",
+                        "value": {
+                            "data": 98,
+                            "type": "integer"
+                        },
+                        "status": "unknown",
+                        "reference": null
+                    },
+                    {
+                        "name": "algorithm-time[0]",
+                        "value": {
+                            "data": "PT0.345000S",
+                            "type": "duration"
+                        },
+                        "status": "unknown",
+                        "reference": null
+                    },
+                    {
+                        "name": "argument[0]",
+                        "value": {
+                            "data": "process argument 1",
+                            "type": "string"
+                        },
+                        "status": "unknown",
+                        "reference": null
+                    },
+                    {
+                        "name": "screenshot-image.png",
+                        "value": {
+                            "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                            "type": "image"
+                        },
+                        "status": "unknown",
+                        "reference": null
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/docs/modules/api/generated/projects/projects_id_webhooks-GET-attributes.csv
+++ b/docs/modules/api/generated/projects/projects_id_webhooks-GET-attributes.csv
@@ -1,0 +1,2 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project to get the webhooks of.

--- a/docs/modules/api/generated/projects/projects_id_webhooks-GET-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_webhooks-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/webhooks

--- a/docs/modules/api/generated/projects/projects_id_webhooks-GET-curl.sh
+++ b/docs/modules/api/generated/projects/projects_id_webhooks-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/projects/1/webhooks

--- a/docs/modules/api/generated/projects/projects_id_webhooks-GET-desc.txt
+++ b/docs/modules/api/generated/projects/projects_id_webhooks-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /projects/:project_id/webhooks

--- a/docs/modules/api/generated/projects/projects_id_webhooks-GET-response.json
+++ b/docs/modules/api/generated/projects/projects_id_webhooks-GET-response.json
@@ -1,0 +1,13 @@
+[
+    {
+        "project": 1,
+        "id": 1,
+        "name": "Demo Bot",
+        "url": "http://129.26.133.164:8666/references/demo",
+        "secret_token": "58a61681-f3c0-4d0f-a8bf-c87193f2603d",
+        "on_submission": false,
+        "on_test_result": false,
+        "on_reference_set": false,
+        "on_test_reference": true
+    }
+]

--- a/docs/modules/api/generated/projects/projects_id_webhooks-POST-attributes.csv
+++ b/docs/modules/api/generated/projects/projects_id_webhooks-POST-attributes.csv
@@ -1,0 +1,9 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project to add the new webhook to.
+``name``|string|yes|The name of the new webhook.
+``url``|url|yes|The URL to be triggered by the webhook.
+``secret_token``|string|yes|This is send in the request header as `X-DTF-Token` and should be used by the client to authenticate the payload.
+``on_submission``|boolean|no (default: ``true``)|Trigger when a submission is created, modified or deleted.
+``on_test_result``|boolean|no (default: ``true``)|Trigger when test results for a submission are created, modified or deleted.
+``on_reference_set``|boolean|no (default: ``true``)|Trigger when a reference set is created, modified or deleted.
+``on_test_reference``|boolean|no (default: ``true``)|Trigger when test references are created, modified or deleted.

--- a/docs/modules/api/generated/projects/projects_id_webhooks-POST-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_webhooks-POST-curl.ps1
@@ -1,0 +1,9 @@
+curl -X POST `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""name"": ""My Webhook"",
+             ""url"": ""http://example.com/my/hook/path"",
+             ""secret_token"": ""sMeyqOYenB8Czi2zGOFHNg"",
+             ""on_submission"": false
+         }' `
+  http://dtf.example.com/api/projects/1/webhooks

--- a/docs/modules/api/generated/projects/projects_id_webhooks-POST-curl.sh
+++ b/docs/modules/api/generated/projects/projects_id_webhooks-POST-curl.sh
@@ -1,0 +1,9 @@
+curl -X POST \
+  --header "Content-Type: application/json" \
+  --data '{
+             "name": "My Webhook",
+             "url": "http://example.com/my/hook/path",
+             "secret_token": "sMeyqOYenB8Czi2zGOFHNg",
+             "on_submission": false
+         }' \
+  http://dtf.example.com/api/projects/1/webhooks

--- a/docs/modules/api/generated/projects/projects_id_webhooks-POST-desc.txt
+++ b/docs/modules/api/generated/projects/projects_id_webhooks-POST-desc.txt
@@ -1,0 +1,1 @@
+POST /projects/:project_id/webhooks

--- a/docs/modules/api/generated/projects/projects_id_webhooks-POST-response.json
+++ b/docs/modules/api/generated/projects/projects_id_webhooks-POST-response.json
@@ -1,0 +1,11 @@
+{
+    "project": 1,
+    "id": 2,
+    "name": "My Webhook",
+    "url": "http://example.com/my/hook/path",
+    "secret_token": "sMeyqOYenB8Czi2zGOFHNg",
+    "on_submission": false,
+    "on_test_result": true,
+    "on_reference_set": true,
+    "on_test_reference": true
+}

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-DELETE-attributes.csv
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-DELETE-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:webhook_id``|integer|yes|The id of the webhook to delete.

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-DELETE-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-DELETE-curl.ps1
@@ -1,0 +1,2 @@
+curl -X DELETE `
+  http://dtf.example.com/api/projects/1/webhooks/2

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-DELETE-curl.sh
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-DELETE-curl.sh
@@ -1,0 +1,2 @@
+curl -X DELETE \
+  http://dtf.example.com/api/projects/1/webhooks/2

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-DELETE-desc.txt
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-DELETE-desc.txt
@@ -1,0 +1,1 @@
+DELETE /projects/:project_id/webhooks/:webhook_id

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-GET-attributes.csv
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-GET-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:webhook_id``|integer|yes|The id of the webhook to get.

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-GET-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/webhooks/1

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-GET-curl.sh
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/projects/1/webhooks/1

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-GET-desc.txt
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /projects/:project_id/webhooks/:webhook_id

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-GET-response.json
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-GET-response.json
@@ -1,0 +1,11 @@
+{
+    "project": 1,
+    "id": 1,
+    "name": "Demo Bot",
+    "url": "http://129.26.133.164:8666/references/demo",
+    "secret_token": "58a61681-f3c0-4d0f-a8bf-c87193f2603d",
+    "on_submission": false,
+    "on_test_result": false,
+    "on_reference_set": false,
+    "on_test_reference": true
+}

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-PUT-attributes.csv
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-PUT-attributes.csv
@@ -1,0 +1,10 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:webhook_id``|integer|yes|The id of the webhook to modify.
+``name``|string|yes|The new name of the webhook.
+``url``|url|yes|The new URL to be triggered by the webhook.
+``secret_token``|string|yes|This is send in the request header as `X-DTF-Token` and should be used by the client to authenticate the payload.
+``on_submission``|boolean|no (default: ``true``)|Trigger when a submission is created, modified or deleted.
+``on_test_result``|boolean|no (default: ``true``)|Trigger when test results for a submission are created, modified or deleted.
+``on_reference_set``|boolean|no (default: ``true``)|Trigger when a reference set is created, modified or deleted.
+``on_test_reference``|boolean|no (default: ``true``)|Trigger when test references are created, modified or deleted.

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-PUT-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-PUT-curl.ps1
@@ -1,0 +1,14 @@
+curl -X PUT `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""project"": 1,
+             ""id"": 1,
+             ""name"": ""Demo Bot"",
+             ""url"": ""http://129.26.133.164:8666/references/demo"",
+             ""secret_token"": ""58a61681-f3c0-4d0f-a8bf-c87193f2603d"",
+             ""on_submission"": true,
+             ""on_test_result"": false,
+             ""on_reference_set"": false,
+             ""on_test_reference"": true
+         }' `
+  http://dtf.example.com/api/projects/1/webhooks/1

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-PUT-curl.sh
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-PUT-curl.sh
@@ -1,0 +1,14 @@
+curl -X PUT \
+  --header "Content-Type: application/json" \
+  --data '{
+             "project": 1,
+             "id": 1,
+             "name": "Demo Bot",
+             "url": "http://129.26.133.164:8666/references/demo",
+             "secret_token": "58a61681-f3c0-4d0f-a8bf-c87193f2603d",
+             "on_submission": true,
+             "on_test_result": false,
+             "on_reference_set": false,
+             "on_test_reference": true
+         }' \
+  http://dtf.example.com/api/projects/1/webhooks/1

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-PUT-desc.txt
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-PUT-desc.txt
@@ -1,0 +1,1 @@
+PUT /projects/:project_id/webhooks/:webhook_id

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id-PUT-response.json
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id-PUT-response.json
@@ -1,0 +1,11 @@
+{
+    "project": 1,
+    "id": 1,
+    "name": "Demo Bot",
+    "url": "http://129.26.133.164:8666/references/demo",
+    "secret_token": "58a61681-f3c0-4d0f-a8bf-c87193f2603d",
+    "on_submission": true,
+    "on_test_result": false,
+    "on_reference_set": false,
+    "on_test_reference": true
+}

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id_logs-GET-attributes.csv
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id_logs-GET-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:webhook_id``|integer|yes|The id of the webhook which's logs to retrieve.

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id_logs-GET-curl.ps1
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id_logs-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/webhooks/1/logs

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id_logs-GET-curl.sh
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id_logs-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/projects/1/webhooks/1/logs

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id_logs-GET-desc.txt
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id_logs-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /projects/:project_id/webhooks/:webhook_id/logs

--- a/docs/modules/api/generated/projects/projects_id_webhooks_id_logs-GET-response.json
+++ b/docs/modules/api/generated/projects/projects_id_webhooks_id_logs-GET-response.json
@@ -1,0 +1,85 @@
+[
+    {
+        "webhook": 1,
+        "created": "2021-04-06T10:03:31.281000+02:00",
+        "request_url": "http://129.26.133.164:8666/references/demo",
+        "request_data": {
+            "event": "create",
+            "source": "testreference",
+            "project": {
+                "id": 1,
+                "name": "Demo Project",
+                "slug": "demo",
+                "created": "2021-04-06T07:21:22.515000Z",
+                "last_updated": "2021-04-06T07:21:22.515000Z",
+                "url": "/demo"
+            },
+            "object": {
+                "reference_set": 1,
+                "test_name": "demo (np=1)",
+                "id": 1,
+                "created": "2021-04-06T08:03:29.072778Z",
+                "last_updated": "2021-04-06T08:03:29.072778Z",
+                "references": {
+                    "runtime": {
+                        "value": {
+                            "data": "PT0.124356S",
+                            "type": "duration"
+                        },
+                        "source": 1
+                    },
+                    "residual[0]": {
+                        "value": {
+                            "data": 2.345,
+                            "type": "float"
+                        },
+                        "source": 1
+                    },
+                    "integer[0]": {
+                        "value": {
+                            "data": 98,
+                            "type": "integer"
+                        },
+                        "source": 1
+                    },
+                    "algorithm-time[0]": {
+                        "value": {
+                            "data": "PT0.345000S",
+                            "type": "duration"
+                        },
+                        "source": 1
+                    },
+                    "argument[0]": {
+                        "value": {
+                            "data": "process argument 1",
+                            "type": "string"
+                        },
+                        "source": 1
+                    },
+                    "argument[1]": {
+                        "value": {
+                            "data": "process argument 2",
+                            "type": "string"
+                        },
+                        "source": 1
+                    },
+                    "screenshot-image.png": {
+                        "value": {
+                            "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                            "type": "image"
+                        },
+                        "source": 1
+                    }
+                }
+            }
+        },
+        "request_headers": {
+            "X-DTF-Token": "58a61681-f3c0-4d0f-a8bf-c87193f2603d",
+            "Content-Length": "2346",
+            "Content-Type": "application/json"
+        },
+        "response_status": 0,
+        "response_data": "HTTPConnectionPool(host='129.26.133.164', port=8666): Max retries exceeded with url: /references/demo (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x00000221DFD1E5E0>: Failed to establish a new connection: [WinError 10061] No connection could be made because the target machine actively refused it'))",
+        "response_headers": {}
+    }
+]

--- a/docs/modules/api/generated/references/projects_id_references-GET-attributes.csv
+++ b/docs/modules/api/generated/references/projects_id_references-GET-attributes.csv
@@ -1,0 +1,2 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project to get the reference sets of.

--- a/docs/modules/api/generated/references/projects_id_references-GET-curl.ps1
+++ b/docs/modules/api/generated/references/projects_id_references-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/references

--- a/docs/modules/api/generated/references/projects_id_references-GET-curl.sh
+++ b/docs/modules/api/generated/references/projects_id_references-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/projects/1/references

--- a/docs/modules/api/generated/references/projects_id_references-GET-desc.txt
+++ b/docs/modules/api/generated/references/projects_id_references-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /projects/:project_id/references

--- a/docs/modules/api/generated/references/projects_id_references-GET-response.json
+++ b/docs/modules/api/generated/references/projects_id_references-GET-response.json
@@ -1,0 +1,12 @@
+[
+    {
+        "project": 1,
+        "id": 1,
+        "created": "2021-04-06T10:03:29.011000+02:00",
+        "last_updated": "2021-04-06T10:03:29.011000+02:00",
+        "property_values": {
+            "Branch": "main",
+            "Hostname": "Vasa"
+        }
+    }
+]

--- a/docs/modules/api/generated/references/projects_id_references-POST-attributes.csv
+++ b/docs/modules/api/generated/references/projects_id_references-POST-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project to add the new reference set to.
+``property_values``|json|no (default: ``{}``)|Property value pairs for the reference set. These have to match the properties specified in the project.

--- a/docs/modules/api/generated/references/projects_id_references-POST-curl.ps1
+++ b/docs/modules/api/generated/references/projects_id_references-POST-curl.ps1
@@ -1,0 +1,9 @@
+curl -X POST `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""property_values"": {
+                 ""Hostname"": ""Vasa"",
+                 ""Branch"": ""feature""
+             }
+         }' `
+  http://dtf.example.com/api/projects/1/references

--- a/docs/modules/api/generated/references/projects_id_references-POST-curl.sh
+++ b/docs/modules/api/generated/references/projects_id_references-POST-curl.sh
@@ -1,0 +1,9 @@
+curl -X POST \
+  --header "Content-Type: application/json" \
+  --data '{
+             "property_values": {
+                 "Hostname": "Vasa",
+                 "Branch": "feature"
+             }
+         }' \
+  http://dtf.example.com/api/projects/1/references

--- a/docs/modules/api/generated/references/projects_id_references-POST-desc.txt
+++ b/docs/modules/api/generated/references/projects_id_references-POST-desc.txt
@@ -1,0 +1,1 @@
+POST /projects/:project_id/references

--- a/docs/modules/api/generated/references/projects_id_references-POST-response.json
+++ b/docs/modules/api/generated/references/projects_id_references-POST-response.json
@@ -1,0 +1,10 @@
+{
+    "project": 1,
+    "id": 2,
+    "created": "2022-02-15T14:49:01.772663+01:00",
+    "last_updated": "2022-02-15T14:49:01.772663+01:00",
+    "property_values": {
+        "Branch": "feature",
+        "Hostname": "Vasa"
+    }
+}

--- a/docs/modules/api/generated/references/projects_id_references_id-DELETE-attributes.csv
+++ b/docs/modules/api/generated/references/projects_id_references_id-DELETE-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:reference_id``|integer|yes|The id of the reference set to delete.

--- a/docs/modules/api/generated/references/projects_id_references_id-DELETE-curl.ps1
+++ b/docs/modules/api/generated/references/projects_id_references_id-DELETE-curl.ps1
@@ -1,0 +1,2 @@
+curl -X DELETE `
+  http://dtf.example.com/api/projects/1/references/2

--- a/docs/modules/api/generated/references/projects_id_references_id-DELETE-curl.sh
+++ b/docs/modules/api/generated/references/projects_id_references_id-DELETE-curl.sh
@@ -1,0 +1,2 @@
+curl -X DELETE \
+  http://dtf.example.com/api/projects/1/references/2

--- a/docs/modules/api/generated/references/projects_id_references_id-DELETE-desc.txt
+++ b/docs/modules/api/generated/references/projects_id_references_id-DELETE-desc.txt
@@ -1,0 +1,1 @@
+DELETE /projects/:project_id/references/:reference_id

--- a/docs/modules/api/generated/references/projects_id_references_id-GET-attributes.csv
+++ b/docs/modules/api/generated/references/projects_id_references_id-GET-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:reference_id``|integer|yes|The id of the reference set to get.

--- a/docs/modules/api/generated/references/projects_id_references_id-GET-curl.ps1
+++ b/docs/modules/api/generated/references/projects_id_references_id-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/references/1

--- a/docs/modules/api/generated/references/projects_id_references_id-GET-curl.sh
+++ b/docs/modules/api/generated/references/projects_id_references_id-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/projects/1/references/1

--- a/docs/modules/api/generated/references/projects_id_references_id-GET-desc.txt
+++ b/docs/modules/api/generated/references/projects_id_references_id-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /projects/:project_id/references/:reference_id

--- a/docs/modules/api/generated/references/projects_id_references_id-GET-response.json
+++ b/docs/modules/api/generated/references/projects_id_references_id-GET-response.json
@@ -1,0 +1,10 @@
+{
+    "project": 1,
+    "id": 1,
+    "created": "2021-04-06T10:03:29.011000+02:00",
+    "last_updated": "2021-04-06T10:03:29.011000+02:00",
+    "property_values": {
+        "Branch": "main",
+        "Hostname": "Vasa"
+    }
+}

--- a/docs/modules/api/generated/references/projects_id_references_id-PUT-attributes.csv
+++ b/docs/modules/api/generated/references/projects_id_references_id-PUT-attributes.csv
@@ -1,0 +1,4 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:reference_id``|integer|yes|The id of the reference set to modify.
+``property_values``|json|no (default: ``{}``)|Property name-value pairs for the reference set. These have to match the properties specified in the project.

--- a/docs/modules/api/generated/references/projects_id_references_id-PUT-curl.ps1
+++ b/docs/modules/api/generated/references/projects_id_references_id-PUT-curl.ps1
@@ -1,0 +1,10 @@
+curl -X PUT `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""project"": 1,
+             ""property_values"": {
+                 ""Hostname"": ""Vasa"",
+                 ""Branch"": ""main""
+             }
+         }' `
+  http://dtf.example.com/api/projects/1/references/1

--- a/docs/modules/api/generated/references/projects_id_references_id-PUT-curl.sh
+++ b/docs/modules/api/generated/references/projects_id_references_id-PUT-curl.sh
@@ -1,0 +1,10 @@
+curl -X PUT \
+  --header "Content-Type: application/json" \
+  --data '{
+             "project": 1,
+             "property_values": {
+                 "Hostname": "Vasa",
+                 "Branch": "main"
+             }
+         }' \
+  http://dtf.example.com/api/projects/1/references/1

--- a/docs/modules/api/generated/references/projects_id_references_id-PUT-desc.txt
+++ b/docs/modules/api/generated/references/projects_id_references_id-PUT-desc.txt
@@ -1,0 +1,1 @@
+PUT /projects/:project_id/references/:reference_id

--- a/docs/modules/api/generated/references/projects_id_references_id-PUT-response.json
+++ b/docs/modules/api/generated/references/projects_id_references_id-PUT-response.json
@@ -1,0 +1,10 @@
+{
+    "project": 1,
+    "id": 1,
+    "created": "2021-04-06T10:03:29.011000+02:00",
+    "last_updated": "2022-02-15T14:49:00.604396+01:00",
+    "property_values": {
+        "Branch": "main",
+        "Hostname": "Vasa"
+    }
+}

--- a/docs/modules/api/generated/submissions/projects_id_submissions-GET-attributes.csv
+++ b/docs/modules/api/generated/submissions/projects_id_submissions-GET-attributes.csv
@@ -1,0 +1,2 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project to get the submissions of.

--- a/docs/modules/api/generated/submissions/projects_id_submissions-GET-curl.ps1
+++ b/docs/modules/api/generated/submissions/projects_id_submissions-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/submissions

--- a/docs/modules/api/generated/submissions/projects_id_submissions-GET-curl.sh
+++ b/docs/modules/api/generated/submissions/projects_id_submissions-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/projects/1/submissions

--- a/docs/modules/api/generated/submissions/projects_id_submissions-GET-desc.txt
+++ b/docs/modules/api/generated/submissions/projects_id_submissions-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /projects/:project_id/submissions

--- a/docs/modules/api/generated/submissions/projects_id_submissions-GET-response.json
+++ b/docs/modules/api/generated/submissions/projects_id_submissions-GET-response.json
@@ -1,0 +1,24 @@
+[
+    {
+        "project": 1,
+        "id": 2,
+        "created": "2021-04-06T10:10:24.740000+02:00",
+        "last_updated": "2021-04-06T10:10:24.740000+02:00",
+        "info": {
+            "Hostname": "Vasa",
+            "Branch": "main"
+        },
+        "url": "http://dtf.example.com/demo/submissions/2"
+    },
+    {
+        "project": 1,
+        "id": 1,
+        "created": "2021-04-06T10:02:57.168000+02:00",
+        "last_updated": "2021-04-06T10:02:57.169000+02:00",
+        "info": {
+            "Hostname": "Vasa",
+            "Branch": "main"
+        },
+        "url": "http://dtf.example.com/demo/submissions/1"
+    }
+]

--- a/docs/modules/api/generated/submissions/projects_id_submissions-POST-attributes.csv
+++ b/docs/modules/api/generated/submissions/projects_id_submissions-POST-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project to add the new submission to.
+``info``|json|no (default: ``{}``)|Property value pairs for the submission. These have to match the properties specified in the project.

--- a/docs/modules/api/generated/submissions/projects_id_submissions-POST-curl.ps1
+++ b/docs/modules/api/generated/submissions/projects_id_submissions-POST-curl.ps1
@@ -1,0 +1,9 @@
+curl -X POST `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""info"": {
+                 ""Hostname"": ""Vasa"",
+                 ""Branch"": ""feature""
+             }
+         }' `
+  http://dtf.example.com/api/projects/1/submissions

--- a/docs/modules/api/generated/submissions/projects_id_submissions-POST-curl.sh
+++ b/docs/modules/api/generated/submissions/projects_id_submissions-POST-curl.sh
@@ -1,0 +1,9 @@
+curl -X POST \
+  --header "Content-Type: application/json" \
+  --data '{
+             "info": {
+                 "Hostname": "Vasa",
+                 "Branch": "feature"
+             }
+         }' \
+  http://dtf.example.com/api/projects/1/submissions

--- a/docs/modules/api/generated/submissions/projects_id_submissions-POST-desc.txt
+++ b/docs/modules/api/generated/submissions/projects_id_submissions-POST-desc.txt
@@ -1,0 +1,1 @@
+POST /projects/:project_id/submissions

--- a/docs/modules/api/generated/submissions/projects_id_submissions-POST-response.json
+++ b/docs/modules/api/generated/submissions/projects_id_submissions-POST-response.json
@@ -1,0 +1,11 @@
+{
+    "project": 1,
+    "id": 3,
+    "created": "2022-02-15T13:10:02.723719+01:00",
+    "last_updated": "2022-02-15T13:10:02.723719+01:00",
+    "info": {
+        "Hostname": "Vasa",
+        "Branch": "feature"
+    },
+    "url": "http://dtf.example.com/demo-project/submissions/3"
+}

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-DELETE-attributes.csv
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-DELETE-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:submission_id``|integer|yes|The id of the submission to delete.

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-DELETE-curl.ps1
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-DELETE-curl.ps1
@@ -1,0 +1,2 @@
+curl -X DELETE `
+  http://dtf.example.com/api/projects/1/submissions/3

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-DELETE-curl.sh
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-DELETE-curl.sh
@@ -1,0 +1,2 @@
+curl -X DELETE \
+  http://dtf.example.com/api/projects/1/submissions/3

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-DELETE-desc.txt
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-DELETE-desc.txt
@@ -1,0 +1,1 @@
+DELETE /projects/:project_id/submissions/:submission_id

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-GET-attributes.csv
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-GET-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:submission_id``|integer|yes|The id of the submission to get.

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-GET-curl.ps1
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/submissions/1

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-GET-curl.sh
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/projects/1/submissions/1

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-GET-desc.txt
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /projects/:project_id/submissions/:submission_id

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-GET-response.json
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-GET-response.json
@@ -1,0 +1,11 @@
+{
+    "project": 1,
+    "id": 1,
+    "created": "2021-04-06T10:02:57.168000+02:00",
+    "last_updated": "2021-04-06T10:02:57.169000+02:00",
+    "info": {
+        "Hostname": "Vasa",
+        "Branch": "main"
+    },
+    "url": "http://dtf.example.com/demo/submissions/1"
+}

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-PUT-attributes.csv
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-PUT-attributes.csv
@@ -1,0 +1,4 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:submission_id``|integer|yes|The id of the submission to modify.
+``info``|json|no (default: ``{}``)|Property name-value pairs for the submission. These have to match the properties specified in the project.

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-PUT-curl.ps1
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-PUT-curl.ps1
@@ -1,0 +1,10 @@
+curl -X PUT `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""project"": 1,
+             ""info"": {
+                 ""Hostname"": ""Vasa"",
+                 ""Branch"": ""feature""
+             }
+         }' `
+  http://dtf.example.com/api/projects/1/submissions/2

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-PUT-curl.sh
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-PUT-curl.sh
@@ -1,0 +1,10 @@
+curl -X PUT \
+  --header "Content-Type: application/json" \
+  --data '{
+             "project": 1,
+             "info": {
+                 "Hostname": "Vasa",
+                 "Branch": "feature"
+             }
+         }' \
+  http://dtf.example.com/api/projects/1/submissions/2

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-PUT-desc.txt
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-PUT-desc.txt
@@ -1,0 +1,1 @@
+PUT /projects/:project_id/submissions/:submission_id

--- a/docs/modules/api/generated/submissions/projects_id_submissions_id-PUT-response.json
+++ b/docs/modules/api/generated/submissions/projects_id_submissions_id-PUT-response.json
@@ -1,0 +1,11 @@
+{
+    "project": 1,
+    "id": 2,
+    "created": "2021-04-06T10:10:24.740000+02:00",
+    "last_updated": "2022-02-15T13:10:01.207524+01:00",
+    "info": {
+        "Hostname": "Vasa",
+        "Branch": "feature"
+    },
+    "url": "http://dtf.example.com/demo/submissions/2"
+}

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests-GET-attributes.csv
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests-GET-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project to get the test references of.
+``:reference_id``|integer|yes|The id of the reference set to get the tests references of.

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests-GET-curl.ps1
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/references/1/tests

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests-GET-curl.sh
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/projects/1/references/1/tests

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests-GET-desc.txt
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /projects/:project_id/references/:reference_id/tests

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests-GET-response.json
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests-GET-response.json
@@ -1,0 +1,60 @@
+[
+    {
+        "reference_set": 1,
+        "test_name": "demo (np=1)",
+        "id": 1,
+        "created": "2021-04-06T08:03:29.072000Z",
+        "last_updated": "2021-04-06T08:03:29.072000Z",
+        "references": {
+            "runtime": {
+                "value": {
+                    "data": "PT0.124356S",
+                    "type": "duration"
+                },
+                "source": 1
+            },
+            "residual[0]": {
+                "value": {
+                    "data": 2.345,
+                    "type": "float"
+                },
+                "source": 1
+            },
+            "integer[0]": {
+                "value": {
+                    "data": 98,
+                    "type": "integer"
+                },
+                "source": 1
+            },
+            "algorithm-time[0]": {
+                "value": {
+                    "data": "PT0.345000S",
+                    "type": "duration"
+                },
+                "source": 1
+            },
+            "argument[0]": {
+                "value": {
+                    "data": "process argument 1",
+                    "type": "string"
+                },
+                "source": 1
+            },
+            "argument[1]": {
+                "value": {
+                    "data": "process argument 2",
+                    "type": "string"
+                },
+                "source": 1
+            },
+            "screenshot-image.png": {
+                "value": {
+                    "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                    "type": "image"
+                },
+                "source": 1
+            }
+        }
+    }
+]

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests-POST-attributes.csv
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests-POST-attributes.csv
@@ -1,0 +1,6 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project of the reference set to create the new test reference for.
+``:reference_id``|integer|yes|The id of the reference set to create a new test reference for.
+``test_name``|string|yes|The name of the test the new references are for.
+``default_source``|integer|no|The id of the submission which is used as default source for references that do not have an explicit source given.
+``references``|json|yes|Test result references. TODO: add JSON schema

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests-POST-curl.ps1
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests-POST-curl.ps1
@@ -1,0 +1,22 @@
+curl -X POST `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""test_name"": ""New Test"",
+             ""default_source"": 2,
+             ""references"": {
+                 ""runtime"": {
+                     ""value"": {
+                         ""data"": ""PT0.124356S"",
+                         ""type"": ""duration""
+                     },
+                     ""source"": 1
+                 },
+                 ""Result1"": {
+                     ""value"": {
+                         ""data"": 123,
+                         ""type"": ""integer""
+                     }
+                 }
+             }
+         }' `
+  http://dtf.example.com/api/projects/1/references/1/tests

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests-POST-curl.sh
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests-POST-curl.sh
@@ -1,0 +1,22 @@
+curl -X POST \
+  --header "Content-Type: application/json" \
+  --data '{
+             "test_name": "New Test",
+             "default_source": 2,
+             "references": {
+                 "runtime": {
+                     "value": {
+                         "data": "PT0.124356S",
+                         "type": "duration"
+                     },
+                     "source": 1
+                 },
+                 "Result1": {
+                     "value": {
+                         "data": 123,
+                         "type": "integer"
+                     }
+                 }
+             }
+         }' \
+  http://dtf.example.com/api/projects/1/references/1/tests

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests-POST-desc.txt
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests-POST-desc.txt
@@ -1,0 +1,1 @@
+POST /projects/:project_id/references/:reference_id/tests

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests-POST-response.json
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests-POST-response.json
@@ -1,0 +1,23 @@
+{
+    "reference_set": 1,
+    "test_name": "New Test",
+    "id": 2,
+    "created": "2023-11-25T15:39:17.566513Z",
+    "last_updated": "2023-11-25T15:39:17.566513Z",
+    "references": {
+        "runtime": {
+            "value": {
+                "data": "PT0.124356S",
+                "type": "duration"
+            },
+            "source": 1
+        },
+        "Result1": {
+            "value": {
+                "data": 123,
+                "type": "integer"
+            },
+            "source": 2
+        }
+    }
+}

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-DELETE-attributes.csv
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-DELETE-attributes.csv
@@ -1,0 +1,4 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:reference_id``|integer|yes|The id of the reference set.
+``:test_id``|integer|yes|The id of the test references to delete.

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-DELETE-curl.ps1
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-DELETE-curl.ps1
@@ -1,0 +1,2 @@
+curl -X DELETE `
+  http://dtf.example.com/api/projects/1/references/1/tests/2

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-DELETE-curl.sh
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-DELETE-curl.sh
@@ -1,0 +1,2 @@
+curl -X DELETE \
+  http://dtf.example.com/api/projects/1/references/1/tests/2

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-DELETE-desc.txt
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-DELETE-desc.txt
@@ -1,0 +1,1 @@
+DELETE /projects/:project_id/references/:reference_id/tests/:test_id

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-GET-attributes.csv
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-GET-attributes.csv
@@ -1,0 +1,4 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:reference_id``|integer|yes|The id of the reference set.
+``:test_id``|integer|yes|The id of the test references to get.

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-GET-curl.ps1
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/references/1/tests/1

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-GET-curl.sh
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/projects/1/references/1/tests/1

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-GET-desc.txt
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /projects/:project_id/references/:reference_id/tests/:test_id

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-GET-response.json
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-GET-response.json
@@ -1,0 +1,58 @@
+{
+    "reference_set": 1,
+    "test_name": "demo (np=1)",
+    "id": 1,
+    "created": "2021-04-06T08:03:29.072000Z",
+    "last_updated": "2021-04-06T08:03:29.072000Z",
+    "references": {
+        "runtime": {
+            "value": {
+                "data": "PT0.124356S",
+                "type": "duration"
+            },
+            "source": 1
+        },
+        "residual[0]": {
+            "value": {
+                "data": 2.345,
+                "type": "float"
+            },
+            "source": 1
+        },
+        "integer[0]": {
+            "value": {
+                "data": 98,
+                "type": "integer"
+            },
+            "source": 1
+        },
+        "algorithm-time[0]": {
+            "value": {
+                "data": "PT0.345000S",
+                "type": "duration"
+            },
+            "source": 1
+        },
+        "argument[0]": {
+            "value": {
+                "data": "process argument 1",
+                "type": "string"
+            },
+            "source": 1
+        },
+        "argument[1]": {
+            "value": {
+                "data": "process argument 2",
+                "type": "string"
+            },
+            "source": 1
+        },
+        "screenshot-image.png": {
+            "value": {
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                "type": "image"
+            },
+            "source": 1
+        }
+    }
+}

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-PUT-attributes.csv
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-PUT-attributes.csv
@@ -1,0 +1,6 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:reference_id``|integer|yes|The id of the reference set.
+``:test_id``|integer|yes|The id of the test references to modify.
+``test_name``|string|yes|The name of the test the references are for.
+``references``|json|yes|Test references. TODO: add JSON schema

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-PUT-curl.ps1
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-PUT-curl.ps1
@@ -1,0 +1,44 @@
+curl -X PUT `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""reference_set"": 1,
+             ""test_name"": ""demo (np=1)"",
+             ""references"": {
+                 ""runtime"": {
+                     ""value"": {
+                         ""data"": ""PT0.124356S"",
+                         ""type"": ""duration""
+                     },
+                     ""source"": 1
+                 },
+                 ""residual[0]"": {
+                     ""value"": {
+                         ""data"": 2.345,
+                         ""type"": ""float""
+                     },
+                     ""source"": 1
+                 },
+                 ""integer[0]"": {
+                     ""value"": {
+                         ""data"": 98,
+                         ""type"": ""integer""
+                     },
+                     ""source"": 1
+                 },
+                 ""algorithm-time[0]"": {
+                     ""value"": {
+                         ""data"": ""PT0.345000S"",
+                         ""type"": ""duration""
+                     },
+                     ""source"": 1
+                 },
+                 ""argument[0]"": {
+                     ""value"": {
+                         ""data"": ""process argument 1"",
+                         ""type"": ""string""
+                     },
+                     ""source"": 1
+                 }
+             }
+         }' `
+  http://dtf.example.com/api/projects/1/references/1/tests/1

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-PUT-curl.sh
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-PUT-curl.sh
@@ -1,0 +1,44 @@
+curl -X PUT \
+  --header "Content-Type: application/json" \
+  --data '{
+             "reference_set": 1,
+             "test_name": "demo (np=1)",
+             "references": {
+                 "runtime": {
+                     "value": {
+                         "data": "PT0.124356S",
+                         "type": "duration"
+                     },
+                     "source": 1
+                 },
+                 "residual[0]": {
+                     "value": {
+                         "data": 2.345,
+                         "type": "float"
+                     },
+                     "source": 1
+                 },
+                 "integer[0]": {
+                     "value": {
+                         "data": 98,
+                         "type": "integer"
+                     },
+                     "source": 1
+                 },
+                 "algorithm-time[0]": {
+                     "value": {
+                         "data": "PT0.345000S",
+                         "type": "duration"
+                     },
+                     "source": 1
+                 },
+                 "argument[0]": {
+                     "value": {
+                         "data": "process argument 1",
+                         "type": "string"
+                     },
+                     "source": 1
+                 }
+             }
+         }' \
+  http://dtf.example.com/api/projects/1/references/1/tests/1

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-PUT-desc.txt
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-PUT-desc.txt
@@ -1,0 +1,1 @@
+PUT /projects/:project_id/references/:reference_id/tests/:test_id

--- a/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-PUT-response.json
+++ b/docs/modules/api/generated/test_references/projects_id_references_id_tests_id-PUT-response.json
@@ -1,0 +1,44 @@
+{
+    "reference_set": 1,
+    "test_name": "demo (np=1)",
+    "id": 1,
+    "created": "2021-04-06T08:03:29.072000Z",
+    "last_updated": "2023-11-25T15:39:12.122702Z",
+    "references": {
+        "runtime": {
+            "value": {
+                "data": "PT0.124356S",
+                "type": "duration"
+            },
+            "source": 1
+        },
+        "residual[0]": {
+            "value": {
+                "data": 2.345,
+                "type": "float"
+            },
+            "source": 1
+        },
+        "integer[0]": {
+            "value": {
+                "data": 98,
+                "type": "integer"
+            },
+            "source": 1
+        },
+        "algorithm-time[0]": {
+            "value": {
+                "data": "PT0.345000S",
+                "type": "duration"
+            },
+            "source": 1
+        },
+        "argument[0]": {
+            "value": {
+                "data": "process argument 1",
+                "type": "string"
+            },
+            "source": 1
+        }
+    }
+}

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-GET-attributes.csv
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-GET-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project to get the test results of.
+``:submission_id``|integer|yes|The id of the submission to get.

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-GET-curl.ps1
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/submissions/1/tests

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-GET-curl.sh
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/projects/1/submissions/1/tests

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-GET-desc.txt
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /projects/:project_id/submissions/:submission_id/tests

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-GET-response.json
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-GET-response.json
@@ -1,0 +1,76 @@
+[
+    {
+        "name": "demo (np=1)",
+        "id": 1,
+        "results": [
+            {
+                "name": "runtime",
+                "value": {
+                    "data": "PT0.124356S",
+                    "type": "duration"
+                },
+                "status": "unknown",
+                "reference": null
+            },
+            {
+                "name": "residual[0]",
+                "value": {
+                    "data": 2.345,
+                    "type": "float"
+                },
+                "status": "unknown",
+                "reference": null
+            },
+            {
+                "name": "integer[0]",
+                "value": {
+                    "data": 98,
+                    "type": "integer"
+                },
+                "status": "unknown",
+                "reference": null
+            },
+            {
+                "name": "algorithm-time[0]",
+                "value": {
+                    "data": "PT0.345000S",
+                    "type": "duration"
+                },
+                "status": "unknown",
+                "reference": null
+            },
+            {
+                "name": "argument[0]",
+                "value": {
+                    "data": "process argument 1",
+                    "type": "string"
+                },
+                "status": "unknown",
+                "reference": null
+            },
+            {
+                "name": "argument[1]",
+                "value": {
+                    "data": "process argument 2",
+                    "type": "string"
+                },
+                "status": "unknown",
+                "reference": null
+            },
+            {
+                "name": "screenshot-image.png",
+                "value": {
+                    "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                    "type": "image"
+                },
+                "status": "unknown",
+                "reference": null
+            }
+        ],
+        "created": "2021-04-06T10:02:57.249000+02:00",
+        "last_updated": "2021-04-06T10:02:57.249000+02:00",
+        "submission": 1,
+        "url": "http://dtf.example.com/demo/tests/1",
+        "status": "unknown"
+    }
+]

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-attributes.csv
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-attributes.csv
@@ -1,0 +1,5 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project of the submission to create the new test for.
+``:submission_id``|integer|yes|The id of the submission to create a new test for.
+``name``|string|yes|The name of the new test.
+``results``|json|no|Test results. TODO: add JSON schema

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-desc.txt
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-desc.txt
@@ -1,0 +1,1 @@
+POST /projects/:project_id/submissions/:submission_id/tests

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-empty-curl.ps1
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-empty-curl.ps1
@@ -1,0 +1,6 @@
+curl -X POST `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""name"": ""New Empty Test""
+         }' `
+  http://dtf.example.com/api/projects/1/submissions/1/tests

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-empty-curl.sh
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-empty-curl.sh
@@ -1,0 +1,6 @@
+curl -X POST \
+  --header "Content-Type: application/json" \
+  --data '{
+             "name": "New Empty Test"
+         }' \
+  http://dtf.example.com/api/projects/1/submissions/1/tests

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-empty-response.json
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-empty-response.json
@@ -1,0 +1,10 @@
+{
+    "name": "New Empty Test",
+    "id": 3,
+    "results": null,
+    "created": "2023-11-25T14:18:40.839354Z",
+    "last_updated": "2023-11-25T14:18:40.839354Z",
+    "submission": 1,
+    "url": "http://dtf.example.com/demo-project/tests/3",
+    "status": "unknown"
+}

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-nonempty-curl.ps1
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-nonempty-curl.ps1
@@ -1,0 +1,17 @@
+curl -X POST `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""name"": ""New Test"",
+             ""results"": [
+                 {
+                     ""name"": ""runtime"",
+                     ""value"": {
+                         ""data"": ""PT0.124356S"",
+                         ""type"": ""duration""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 }
+             ]
+         }' `
+  http://dtf.example.com/api/projects/1/submissions/1/tests

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-nonempty-curl.sh
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-nonempty-curl.sh
@@ -1,0 +1,17 @@
+curl -X POST \
+  --header "Content-Type: application/json" \
+  --data '{
+             "name": "New Test",
+             "results": [
+                 {
+                     "name": "runtime",
+                     "value": {
+                         "data": "PT0.124356S",
+                         "type": "duration"
+                     },
+                     "status": "unknown",
+                     "reference": null
+                 }
+             ]
+         }' \
+  http://dtf.example.com/api/projects/1/submissions/1/tests

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-nonempty-response.json
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests-POST-nonempty-response.json
@@ -1,0 +1,20 @@
+{
+    "name": "New Test",
+    "id": 4,
+    "results": [
+        {
+            "name": "runtime",
+            "value": {
+                "data": "PT0.124356S",
+                "type": "duration"
+            },
+            "status": "unknown",
+            "reference": null
+        }
+    ],
+    "created": "2023-11-25T14:18:41.896178Z",
+    "last_updated": "2023-11-25T14:18:41.896178Z",
+    "submission": 1,
+    "url": "http://dtf.example.com/demo-project/tests/4",
+    "status": "unknown"
+}

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-DELETE-attributes.csv
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-DELETE-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:test_id``|integer|yes|The id of the test results to delete.

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-DELETE-curl.ps1
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-DELETE-curl.ps1
@@ -1,0 +1,2 @@
+curl -X DELETE `
+  http://dtf.example.com/api/projects/1/submissions/2/tests/2

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-DELETE-curl.sh
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-DELETE-curl.sh
@@ -1,0 +1,2 @@
+curl -X DELETE \
+  http://dtf.example.com/api/projects/1/submissions/2/tests/2

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-DELETE-desc.txt
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-DELETE-desc.txt
@@ -1,0 +1,1 @@
+DELETE /projects/:project_id/submissions/:submission_id/tests/:test_id

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-GET-attributes.csv
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-GET-attributes.csv
@@ -1,0 +1,3 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:test_id``|integer|yes|The id of the test results to get.

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-GET-curl.ps1
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-GET-curl.ps1
@@ -1,0 +1,2 @@
+curl -X GET `
+  http://dtf.example.com/api/projects/1/submissions/1/tests/1

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-GET-curl.sh
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-GET-curl.sh
@@ -1,0 +1,2 @@
+curl -X GET \
+  http://dtf.example.com/api/projects/1/submissions/1/tests/1

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-GET-desc.txt
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-GET-desc.txt
@@ -1,0 +1,1 @@
+GET /projects/:project_id/submissions/:submission_id/tests/:test_id

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-GET-response.json
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-GET-response.json
@@ -1,0 +1,74 @@
+{
+    "name": "demo (np=1)",
+    "id": 1,
+    "results": [
+        {
+            "name": "runtime",
+            "value": {
+                "data": "PT0.124356S",
+                "type": "duration"
+            },
+            "status": "unknown",
+            "reference": null
+        },
+        {
+            "name": "residual[0]",
+            "value": {
+                "data": 2.345,
+                "type": "float"
+            },
+            "status": "unknown",
+            "reference": null
+        },
+        {
+            "name": "integer[0]",
+            "value": {
+                "data": 98,
+                "type": "integer"
+            },
+            "status": "unknown",
+            "reference": null
+        },
+        {
+            "name": "algorithm-time[0]",
+            "value": {
+                "data": "PT0.345000S",
+                "type": "duration"
+            },
+            "status": "unknown",
+            "reference": null
+        },
+        {
+            "name": "argument[0]",
+            "value": {
+                "data": "process argument 1",
+                "type": "string"
+            },
+            "status": "unknown",
+            "reference": null
+        },
+        {
+            "name": "argument[1]",
+            "value": {
+                "data": "process argument 2",
+                "type": "string"
+            },
+            "status": "unknown",
+            "reference": null
+        },
+        {
+            "name": "screenshot-image.png",
+            "value": {
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                "type": "image"
+            },
+            "status": "unknown",
+            "reference": null
+        }
+    ],
+    "created": "2021-04-06T08:02:57.249000Z",
+    "last_updated": "2021-04-06T08:02:57.249000Z",
+    "submission": 1,
+    "url": "http://dtf.example.com/demo/tests/1",
+    "status": "unknown"
+}

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-PUT-attributes.csv
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-PUT-attributes.csv
@@ -1,0 +1,6 @@
+Attribute|Type|Required|Description
+``:project_id``|string/integer|yes|The id or slug of the project.
+``:test_id``|integer|yes|The id of the test results to modify.
+``name``|string|yes|The new name of the test.
+``status``|string|yes|Status of the test. Allowed values are 'skip', 'successful', 'unstable', 'unknown', 'failed', or 'broken'.
+``results``|json|yes|Test results. TODO: add JSON schema

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-PUT-curl.ps1
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-PUT-curl.ps1
@@ -1,0 +1,64 @@
+curl -X PUT `
+  --header "Content-Type: application/json" `
+  --data '{
+             ""submission"": 1,
+             ""name"": ""demo (np=1)"",
+             ""status"": ""failed"",
+             ""results"": [
+                 {
+                     ""name"": ""runtime"",
+                     ""value"": {
+                         ""data"": ""PT0.124356S"",
+                         ""type"": ""duration""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 },
+                 {
+                     ""name"": ""residual[0]"",
+                     ""value"": {
+                         ""data"": 2.345,
+                         ""type"": ""float""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 },
+                 {
+                     ""name"": ""integer[0]"",
+                     ""value"": {
+                         ""data"": 98,
+                         ""type"": ""integer""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 },
+                 {
+                     ""name"": ""algorithm-time[0]"",
+                     ""value"": {
+                         ""data"": ""PT0.345000S"",
+                         ""type"": ""duration""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 },
+                 {
+                     ""name"": ""argument[0]"",
+                     ""value"": {
+                         ""data"": ""process argument 1"",
+                         ""type"": ""string""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 },
+                 {
+                     ""name"": ""screenshot-image.png"",
+                     ""value"": {
+                         ""data"": ""iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII="",
+                         ""type"": ""image""
+                     },
+                     ""status"": ""unknown"",
+                     ""reference"": null
+                 }
+             ]
+         }' `
+  http://dtf.example.com/api/projects/1/submissions/1/tests/1

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-PUT-curl.sh
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-PUT-curl.sh
@@ -1,0 +1,64 @@
+curl -X PUT \
+  --header "Content-Type: application/json" \
+  --data '{
+             "submission": 1,
+             "name": "demo (np=1)",
+             "status": "failed",
+             "results": [
+                 {
+                     "name": "runtime",
+                     "value": {
+                         "data": "PT0.124356S",
+                         "type": "duration"
+                     },
+                     "status": "unknown",
+                     "reference": null
+                 },
+                 {
+                     "name": "residual[0]",
+                     "value": {
+                         "data": 2.345,
+                         "type": "float"
+                     },
+                     "status": "unknown",
+                     "reference": null
+                 },
+                 {
+                     "name": "integer[0]",
+                     "value": {
+                         "data": 98,
+                         "type": "integer"
+                     },
+                     "status": "unknown",
+                     "reference": null
+                 },
+                 {
+                     "name": "algorithm-time[0]",
+                     "value": {
+                         "data": "PT0.345000S",
+                         "type": "duration"
+                     },
+                     "status": "unknown",
+                     "reference": null
+                 },
+                 {
+                     "name": "argument[0]",
+                     "value": {
+                         "data": "process argument 1",
+                         "type": "string"
+                     },
+                     "status": "unknown",
+                     "reference": null
+                 },
+                 {
+                     "name": "screenshot-image.png",
+                     "value": {
+                         "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                         "type": "image"
+                     },
+                     "status": "unknown",
+                     "reference": null
+                 }
+             ]
+         }' \
+  http://dtf.example.com/api/projects/1/submissions/1/tests/1

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-PUT-desc.txt
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-PUT-desc.txt
@@ -1,0 +1,1 @@
+PUT /projects/:project_id/submissions/:submission_id/tests/:test_id

--- a/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-PUT-response.json
+++ b/docs/modules/api/generated/test_results/projects_id_submissions_id_tests_id-PUT-response.json
@@ -1,0 +1,65 @@
+{
+    "name": "demo (np=1)",
+    "id": 1,
+    "results": [
+        {
+            "name": "runtime",
+            "value": {
+                "data": "PT0.124356S",
+                "type": "duration"
+            },
+            "status": "unknown",
+            "reference": null
+        },
+        {
+            "name": "residual[0]",
+            "value": {
+                "data": 2.345,
+                "type": "float"
+            },
+            "status": "unknown",
+            "reference": null
+        },
+        {
+            "name": "integer[0]",
+            "value": {
+                "data": 98,
+                "type": "integer"
+            },
+            "status": "unknown",
+            "reference": null
+        },
+        {
+            "name": "algorithm-time[0]",
+            "value": {
+                "data": "PT0.345000S",
+                "type": "duration"
+            },
+            "status": "unknown",
+            "reference": null
+        },
+        {
+            "name": "argument[0]",
+            "value": {
+                "data": "process argument 1",
+                "type": "string"
+            },
+            "status": "unknown",
+            "reference": null
+        },
+        {
+            "name": "screenshot-image.png",
+            "value": {
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAODaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS4zLWMwMTEgNjYuMTQ1NjYxLCAyMDEyLzAyLzA2LTE0OjU2OjI3ICAgICAgICAiPg0KICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPg0KICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NjI3NTk3QzkxNTIwNjgxMTk3QTVENkZCNTAzMEMyMUMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUE0Q0YyRTc0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUE0Q0YyRTY0RTlGMTFFMzhFQkFEREEzMjM4MTA0NDIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+DQogICAgICA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNTgwMTE3NDA3MjA2ODExODIyQUE3NDk3QjdFNzQyMSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2Mjc1OTdDOTE1MjA2ODExOTdBNUQ2RkI1MDMwQzIxQyIgLz4NCiAgICA8L3JkZjpEZXNjcmlwdGlvbj4NCiAgPC9yZGY6UkRGPg0KPC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSJyIj8+VtnJzwAAABZJREFUGFdj/M/A8M3iP6OxyH+u13EAKIYFyOIlKZYAAAAASUVORK5CYII=",
+                "type": "image"
+            },
+            "status": "unknown",
+            "reference": null
+        }
+    ],
+    "created": "2021-04-06T08:02:57.249000Z",
+    "last_updated": "2023-11-25T14:18:31.977796Z",
+    "submission": 1,
+    "url": "http://dtf.example.com/demo/tests/1",
+    "status": "unknown"
+}

--- a/docs/modules/api/generated/test_results/projects_id_tests_id-PUT-response.json
+++ b/docs/modules/api/generated/test_results/projects_id_tests_id-PUT-response.json
@@ -58,7 +58,7 @@
         }
     ],
     "created": "2021-04-06T10:02:57.249000+02:00",
-    "last_updated": "2021-07-18T20:48:31.523772+02:00",
+    "last_updated": "2022-02-15T11:34:09.626776+01:00",
     "submission": 1,
     "url": "http://dtf.example.com/demo/tests/1",
     "status": "unknown"

--- a/docs/modules/api/projects.rst
+++ b/docs/modules/api/projects.rst
@@ -331,6 +331,8 @@ An example could look as follows:
       .. literalinclude :: generated/projects/projects_id_properties_id-DELETE-curl.ps1
          :language: PowerShell
 
+.. _api-projects-members-list:
+
 List project members
 --------------------
 
@@ -490,4 +492,196 @@ An example could look as follows:
       .. literalinclude :: generated/projects/projects_id_members_id-DELETE-curl.ps1
          :language: PowerShell
 
-.. _api-projects-members-list:
+.. _api-projects-webhooks-list:
+
+List project webhooks
+---------------------
+
+List all webhooks of a given project.
+
+.. literalinclude :: generated/projects/projects_id_webhooks-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/projects/projects_id_webhooks-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_webhooks-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_webhooks-GET-curl.ps1
+         :language: PowerShell
+
+which might give a result like this:
+
+.. literalinclude :: generated/projects/projects_id_webhooks-GET-response.json
+   :language: json
+
+.. _api-projects-webhooks-new:
+
+Add new project webhook
+-----------------------
+
+Add a new webhook to a project.
+
+.. literalinclude :: generated/projects/projects_id_webhooks-POST-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/projects/projects_id_webhooks-POST-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_webhooks-POST-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_webhooks-POST-curl.ps1
+         :language: PowerShell
+
+which might give a result like this:
+
+.. literalinclude :: generated/projects/projects_id_webhooks-POST-response.json
+    :language: json
+
+
+.. _api-projects-webhooks-get:
+
+Get single project webhook
+--------------------------
+
+Retrieve a specific webhook from a project.
+
+.. literalinclude :: generated/projects/projects_id_webhooks_id-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/projects/projects_id_webhooks_id-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_webhooks_id-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_webhooks_id-GET-curl.ps1
+         :language: PowerShell
+
+which might give a result like this:
+
+.. literalinclude :: generated/projects/projects_id_webhooks_id-GET-response.json
+   :language: json
+
+.. _api-projects-webhooks-modify:
+
+Modify project webhook
+----------------------
+
+Modify the fields of an existing webhook. All fields have to be given (even the ones that are unchanged).
+
+.. literalinclude :: generated/projects/projects_id_webhooks_id-PUT-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/projects/projects_id_webhooks_id-PUT-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_webhooks_id-PUT-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_webhooks_id-PUT-curl.ps1
+         :language: PowerShell
+
+which might give a result like this:
+
+.. literalinclude :: generated/projects/projects_id_webhooks_id-PUT-response.json
+    :language: json
+
+.. _api-projects-webhooks-delete:
+
+Delete project webhook
+----------------------
+
+Deletes a webhook from a project. This can not be undone!
+
+.. literalinclude :: generated/projects/projects_id_webhooks_id-DELETE-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/projects/projects_id_webhooks_id-DELETE-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_webhooks_id-DELETE-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_webhooks_id-DELETE-curl.ps1
+         :language: PowerShell
+
+.. _api-projects-webhooks-logs-get:
+
+Retrieve logs of a webhook
+--------------------------
+
+Retrieves the history of trigger events for a webhook.
+
+.. literalinclude :: generated/projects/projects_id_webhooks_id_logs-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/projects/projects_id_webhooks_id_logs-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/projects/projects_id_webhooks_id_logs-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/projects/projects_id_webhooks_id_logs-GET-curl.ps1
+         :language: PowerShell
+
+which might give a result like this:
+
+.. literalinclude :: generated/projects/projects_id_webhooks_id_logs-GET-response.json
+    :language: json

--- a/docs/modules/api/references.rst
+++ b/docs/modules/api/references.rst
@@ -1,2 +1,165 @@
 References API
 ==============
+
+.. _api-references-list:
+
+List reference sets of a project
+--------------------------------
+
+List all reference sets of a given project.
+
+.. literalinclude :: generated/references/projects_id_references-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/references/projects_id_references-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/references/projects_id_references-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/references/projects_id_references-GET-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/references/projects_id_references-GET-response.json
+   :language: json
+
+
+.. _api-references-new:
+
+Create new reference set
+------------------------
+
+Create a new, empty reference set for the project.
+
+.. literalinclude :: generated/references/projects_id_references-POST-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/references/projects_id_references-POST-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/references/projects_id_references-POST-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/references/projects_id_references-POST-curl.ps1
+         :language: PowerShell
+
+which might give a result like this:
+
+.. literalinclude :: generated/references/projects_id_references-POST-response.json
+    :language: json
+
+
+.. _api-references-get:
+
+Get single reference set of a project
+-------------------------------------
+
+Retrieve a specific reference set from a project.
+
+.. literalinclude :: generated/references/projects_id_references_id-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/references/projects_id_references_id-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/references/projects_id_references_id-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/references/projects_id_references_id-GET-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/references/projects_id_references_id-GET-response.json
+   :language: json
+
+.. _api-references-modify:
+
+Modify reference sets of a project
+----------------------------------
+
+Modify the fields of an existing reference set. All fields have to be given (even the ones that are unchanged).
+
+.. literalinclude :: generated/references/projects_id_references_id-PUT-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/references/projects_id_references_id-PUT-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/references/projects_id_references_id-PUT-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/references/projects_id_references_id-PUT-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/references/projects_id_references_id-PUT-response.json
+    :language: json
+
+
+.. _api-references-delete:
+
+Delete reference sets of a project
+----------------------------------
+
+Deletes a reference set and all its associated data (like test result references) from a project. This can not be undone!
+
+.. literalinclude :: generated/references/projects_id_references_id-DELETE-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/references/projects_id_references_id-DELETE-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/references/projects_id_references_id-DELETE-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/references/projects_id_references_id-DELETE-curl.ps1
+         :language: powershell

--- a/docs/modules/api/submissions.rst
+++ b/docs/modules/api/submissions.rst
@@ -1,2 +1,165 @@
 Submissions API
 ===============
+
+.. _api-submissions-list:
+
+List submissions of a project
+-----------------------------
+
+List all submissions of a given project.
+
+.. literalinclude :: generated/submissions/projects_id_submissions-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/submissions/projects_id_submissions-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/submissions/projects_id_submissions-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/submissions/projects_id_submissions-GET-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/submissions/projects_id_submissions-GET-response.json
+   :language: json
+
+
+.. _api-submissions-new:
+
+Create new submission
+---------------------
+
+Create a new, empty submission for the project.
+
+.. literalinclude :: generated/submissions/projects_id_submissions-POST-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/submissions/projects_id_submissions-POST-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/submissions/projects_id_submissions-POST-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/submissions/projects_id_submissions-POST-curl.ps1
+         :language: PowerShell
+
+which might give a result like this:
+
+.. literalinclude :: generated/submissions/projects_id_submissions-POST-response.json
+    :language: json
+
+
+.. _api-submissions-get:
+
+Get single submission of a project
+----------------------------------
+
+Retrieve a specific submission from a project.
+
+.. literalinclude :: generated/submissions/projects_id_submissions_id-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/submissions/projects_id_submissions_id-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/submissions/projects_id_submissions_id-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/submissions/projects_id_submissions_id-GET-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/submissions/projects_id_submissions_id-GET-response.json
+   :language: json
+
+.. _api-submissions-modify:
+
+Modify submissions of a project
+-------------------------------
+
+Modify the fields of an existing submission. All fields have to be given (even the ones that are unchanged).
+
+.. literalinclude :: generated/submissions/projects_id_submissions_id-PUT-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/submissions/projects_id_submissions_id-PUT-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/submissions/projects_id_submissions_id-PUT-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/submissions/projects_id_submissions_id-PUT-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/submissions/projects_id_submissions_id-PUT-response.json
+    :language: json
+
+
+.. _api-submissions-delete:
+
+Delete submissions of a project
+-------------------------------
+
+Deletes a submission and all its associated data (like test results) from a project. This can not be undone!
+
+.. literalinclude :: generated/submissions/projects_id_submissions_id-DELETE-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/submissions/projects_id_submissions_id-DELETE-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/submissions/projects_id_submissions_id-DELETE-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/submissions/projects_id_submissions_id-DELETE-curl.ps1
+         :language: powershell

--- a/docs/modules/api/test_references.rst
+++ b/docs/modules/api/test_references.rst
@@ -1,0 +1,166 @@
+Rest References API
+===================
+
+.. _api-test_references-reference_set-list:
+
+List test references of a reference set
+---------------------------------------
+
+List all test references from a reference set.
+
+.. literalinclude :: generated/test_references/projects_id_references_id_tests-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/test_references/projects_id_references_id_tests-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_references/projects_id_references_id_tests-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_references/projects_id_references_id_tests-GET-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/test_references/projects_id_references_id_tests-GET-response.json
+   :language: json
+
+
+.. _api-test_references-reference_set-create:
+
+Add new test reference to a reference set
+-----------------------------------------
+
+Add a new test reference to the reference set.
+
+.. literalinclude :: generated/test_references/projects_id_references_id_tests-POST-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/test_references/projects_id_references_id_tests-POST-attributes.csv
+   :delim: |
+
+An example to create a new test reference could look like this:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_references/projects_id_references_id_tests-POST-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_references/projects_id_references_id_tests-POST-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/test_references/projects_id_references_id_tests-POST-response.json
+   :language: json
+
+
+.. _api-test_references-reference_set-get:
+
+Get single test reference of a reference set
+--------------------------------------------
+
+Retrieve a specific test reference from a reference set.
+
+.. literalinclude :: generated/test_references/projects_id_references_id_tests_id-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/test_references/projects_id_references_id_tests_id-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_references/projects_id_references_id_tests_id-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_references/projects_id_references_id_tests_id-GET-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/test_references/projects_id_references_id_tests_id-GET-response.json
+   :language: json
+
+
+.. _api-test_references-reference_set-modify:
+
+Modify test references of a reference set
+-----------------------------------------
+
+Modify the fields of an existing test reference. All fields have to be given (even the ones that are unchanged).
+
+.. literalinclude :: generated/test_references/projects_id_references_id_tests_id-PUT-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/test_references/projects_id_references_id_tests_id-PUT-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_references/projects_id_references_id_tests_id-PUT-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_references/projects_id_references_id_tests_id-PUT-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/test_references/projects_id_references_id_tests_id-PUT-response.json
+    :language: json
+
+
+.. _api-test_references-reference_set-delete:
+
+Delete test reference of a reference set
+----------------------------------------
+
+Deletes a test reference from a reference set. This can not be undone!
+
+.. literalinclude :: generated/test_references/projects_id_references_id_tests_id-DELETE-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/test_references/projects_id_references_id_tests_id-DELETE-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_references/projects_id_references_id_tests_id-DELETE-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_references/projects_id_references_id_tests_id-DELETE-curl.ps1
+         :language: powershell

--- a/docs/modules/api/test_results.rst
+++ b/docs/modules/api/test_results.rst
@@ -35,6 +35,40 @@ which might give a result like this:
    :language: json
 
 
+.. _api-test_results-submissions-list:
+
+List test results of a submission
+---------------------------------
+
+List all test results from a specific submission of a given project.
+
+.. literalinclude :: generated/test_results/projects_id_tests-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/test_results/projects_id_submissions_id_tests-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests-GET-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/test_results/projects_id_submissions_id_tests-GET-response.json
+   :language: json
+
+
 .. _api-test_results-project-get:
 
 Get single test result of a project

--- a/docs/modules/api/test_results.rst
+++ b/docs/modules/api/test_results.rst
@@ -35,40 +35,6 @@ which might give a result like this:
    :language: json
 
 
-.. _api-test_results-submissions-list:
-
-List test results of a submission
----------------------------------
-
-List all test results from a specific submission of a given project.
-
-.. literalinclude :: generated/test_results/projects_id_tests-GET-desc.txt
-
-.. csv-table::
-   :header-rows: 1
-   :file: generated/test_results/projects_id_submissions_id_tests-GET-attributes.csv
-   :delim: |
-
-An example could look as follows:
-
-.. tabs::
-
-   .. group-tab:: Bash
-
-      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests-GET-curl.sh
-         :language: bash
-
-   .. group-tab:: PowerShell
-
-      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests-GET-curl.ps1
-         :language: powershell
-
-which might give a result like this:
-
-.. literalinclude :: generated/test_results/projects_id_submissions_id_tests-GET-response.json
-   :language: json
-
-
 .. _api-test_results-project-get:
 
 Get single test result of a project
@@ -164,13 +130,197 @@ An example could look as follows:
          :language: powershell
 
 
+.. _api-test_results-submissions-list:
+
+List test results of a submission
+---------------------------------
+
+List all test results from a specific submission of a given project.
+
+.. literalinclude :: generated/test_results/projects_id_submissions_id_tests-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/test_results/projects_id_submissions_id_tests-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests-GET-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/test_results/projects_id_submissions_id_tests-GET-response.json
+   :language: json
+
+
+.. _api-test_results-submissions-create:
+
+Add new test result to a submission
+-----------------------------------
+
+Add a new test result to the submission.
+
+.. literalinclude :: generated/test_results/projects_id_submissions_id_tests-POST-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/test_results/projects_id_submissions_id_tests-POST-attributes.csv
+   :delim: |
+
+An example to create an empty test result could look like this:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests-POST-empty-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests-POST-empty-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/test_results/projects_id_submissions_id_tests-POST-empty-response.json
+   :language: json
+
+Or an example to create a test with some initial results:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests-POST-nonempty-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests-POST-nonempty-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/test_results/projects_id_submissions_id_tests-POST-nonempty-response.json
+   :language: json
+
+
+.. _api-test_results-submissions-get:
+
+Get single test result of a submission
+--------------------------------------
+
+Retrieve a specific test result from a submission.
+
+.. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id-GET-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/test_results/projects_id_submissions_id_tests_id-GET-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id-GET-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id-GET-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id-GET-response.json
+   :language: json
+
+
+.. _api-test_results-submissions-modify:
+
+Modify test results of a submission
+-----------------------------------
+
+Modify the fields of an existing test result. All fields have to be given (even the ones that are unchanged).
+
+.. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id-PUT-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/test_results/projects_id_submissions_id_tests_id-PUT-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id-PUT-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id-PUT-curl.ps1
+         :language: powershell
+
+which might give a result like this:
+
+.. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id-PUT-response.json
+    :language: json
+
+
+.. _api-test_results-submissions-delete:
+
+Delete test results of a submission
+-----------------------------------
+
+Deletes a test result from a submission. This can not be undone!
+
+.. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id-DELETE-desc.txt
+
+.. csv-table::
+   :header-rows: 1
+   :file: generated/test_results/projects_id_submissions_id_tests_id-DELETE-attributes.csv
+   :delim: |
+
+An example could look as follows:
+
+.. tabs::
+
+   .. group-tab:: Bash
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id-DELETE-curl.sh
+         :language: bash
+
+   .. group-tab:: PowerShell
+
+      .. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id-DELETE-curl.ps1
+         :language: powershell
+
+
 .. _api-test_results-history:
 
 History of a test result measurement
 ------------------------------------
 
 Retrieves the history of a measurement for a given test.
-The history is extracted for the all test results of that project that belong to a submission
+The history is extracted for all test results of that project that belong to a submission
 which has the same *reference relevant properties* as the submission the current test belongs to.
 
 .. literalinclude :: generated/test_results/projects_id_submissions_id_tests_id_history-GET-desc.txt

--- a/docs/regenerate_api_docs.py
+++ b/docs/regenerate_api_docs.py
@@ -159,6 +159,7 @@ else:
     print("Starting server")
     env = dict(os.environ)
     env['DTF_DEFAULT_DATABASE'] = 'demo'
+    env['DTF_ENABLE_WEBHOOKS'] = '0'
     with open('server_output.txt', 'w') as server_output:
         with subprocess.Popen(args=[sys.executable, "-u", manage_script_path, "runserver"], stdout=server_output, stderr=subprocess.STDOUT, cwd=root_path, env=env) as server_process:
             print(f"Started server with pid: {server_process.pid}")

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@ django>=3.1
 djangorestframework
 jsonschema
 sphinx
-sphinx_hand_theme
+sphinx_rtd_theme
 sphinx_tabs
 pygments>=2.9
+psutil

--- a/dtf/forms.py
+++ b/dtf/forms.py
@@ -85,7 +85,7 @@ class WebhookForm(forms.ModelForm):
             'project': forms.HiddenInput()
         }
         help_texts = {
-            'secret_token': mark_safe('This is send in the reqest header as <b>X-DTF-Token</b> and should be used by the client to authenticate the payload.'),
+            'secret_token': mark_safe('This is send in the request header as <b>X-DTF-Token</b> and should be used by the client to authenticate the payload.'),
             'on_submission': 'Trigger when a submission is created, modified or deleted.',
             'on_test_result': 'Trigger when test results for a submission are created, modified or deleted.',
             'on_reference_set': 'Trigger when a reference set is created, modified or deleted.',


### PR DESCRIPTION
This MR adds API documentation for the following endpoints:

- [x] `api/projects/<str:project_id>/webhooks`
- [x] `api/projects/<str:project_id>/webhooks/<str:webhook_id>`
- [x] `api/projects/<str:project_id>/webhooks/<str:webhook_id>/logs`
- [x] `api/projects/<str:project_id>/submissions`
- [x] `api/projects/<str:project_id>/submissions/<str:submission_id>`
- [x] `api/projects/<str:project_id>/submissions/<str:submission_id>/tests`
- [x] `api/projects/<str:project_id>/submissions/<str:submission_id>/tests/<str:test_id>`
- [x] `api/projects/<str:project_id>/references`
- [x] `api/projects/<str:project_id>/references/<str:reference_id>`
- [x] `api/projects/<str:project_id>/references/<str:reference_id>/tests`
- [x] `api/projects/<str:project_id>/references/<str:reference_id>/tests/<str:test_id>`