### PR TITLE
Add basic support to PATCH a TestResult

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: [3.7, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/dtf/api.py
+++ b/dtf/api.py
@@ -382,13 +382,14 @@ class TestMeasurementHistory(views.APIView, ProjectAPIViewMixin):
                 'value_source' : test.id,
                 'date' : test.created
             }
-            for measurement in test.results:
-                if measurement['name'] == measurement_name:
-                    entry['value'] = copy.deepcopy(measurement['value'])
-                    entry['reference'] = copy.deepcopy(measurement['reference'])
-                    entry['status'] = copy.deepcopy(measurement['status'])
-                    entry['reference_source'] = measurement.get('reference_source')
-                    break
+            if test.results is not None:
+                for measurement in test.results:
+                    if measurement['name'] == measurement_name:
+                        entry['value'] = copy.deepcopy(measurement['value'])
+                        entry['reference'] = copy.deepcopy(measurement['reference'])
+                        entry['status'] = copy.deepcopy(measurement['status'])
+                        entry['reference_source'] = measurement.get('reference_source')
+                        break
             data.append(entry)
 
         return Response(data, status.HTTP_200_OK)

--- a/dtf/functions.py
+++ b/dtf/functions.py
@@ -9,25 +9,6 @@ def create_reference_query(project, query_params):
                 queries['property_values__' + prop.name] = prop_value
     return queries
 
-def fill_result_default_values(results, test_name, submission):
-    reference_query = create_reference_query(submission.project, submission.info)
-    reference_set = submission.project.reference_sets.filter(**reference_query).first()
-
-    if reference_set is not None:
-        current_reference = reference_set.test_references.filter(test_name=test_name).first()
-    else:
-        current_reference = None
-
-    for result in results:
-        if not 'reference' in result:
-            if current_reference is not None:
-                result['reference'] = current_reference.get_reference_or_none(result['name'])
-            else:
-                result['reference'] = None
-        if not 'status' in result:
-            result['status'] = 'unknown'
-    return results
-
 def get_project_by_id(project_id, queryset):
     """
     Retrieve a project by its Id. Returns None if no project is found.

--- a/dtf/models.py
+++ b/dtf/models.py
@@ -347,9 +347,10 @@ class TestResult(models.Model):
 
     def calculate_status(self):
         status = None
-        for result in self.results:
-            if status is None or self.status_order[result['status']] > self.status_order[status]:
-                status = result['status']
+        if self.results is not None:
+            for result in self.results:
+                if status is None or self.status_order[result['status']] > self.status_order[status]:
+                    status = result['status']
         if status is None:
             self.status = "unknown"
         else:

--- a/dtf/tests/test_api.py
+++ b/dtf/tests/test_api.py
@@ -575,7 +575,7 @@ class SubmissionApiTest(ApiTestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(Project.objects.count(), 1)
 
-class TestResultsApiTest(ApiTestCase):
+class SubmissionTestResultsApiTest(ApiTestCase):
     """ Test module for submitting test results via the API """
 
     def setUp(self):
@@ -766,7 +766,7 @@ class TestResultsApiTest(ApiTestCase):
         self.assertEqual(response.data, serializer.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-class TestResultApiTest(ApiTestCase):
+class SubmissionTestResultApiTest(ApiTestCase):
     def setUp(self):
         super().setUp()
         _, data = self.create_project("Test Project", "test-project")
@@ -785,6 +785,11 @@ class TestResultApiTest(ApiTestCase):
         self.url_2 = reverse('api_project_submission_test', kwargs={'project_id' : self.project_id, 'submission_id' : self.submission_id, 'test_id' : self.test_2_id})
         self.test_2 = TestResult.objects.get(id=self.test_2_id)
 
+        response, data = self.post(create_url, {'name' : 'Test 3'})
+        self.test_3_id = data['id']
+        self.url_3 = reverse('api_project_submission_test', kwargs={'project_id' : self.project_id, 'submission_id' : self.submission_id, 'test_id' : self.test_3_id})
+        self.test_3 = TestResult.objects.get(id=self.test_3_id)
+
     def test_get(self):
         response = client.get(self.url_1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -794,6 +799,11 @@ class TestResultApiTest(ApiTestCase):
         response = client.get(self.url_2)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         serializer = TestResultSerializer(self.test_2, context={"request": response.wsgi_request})
+        self.assertEqual(response.data, serializer.data)
+
+        response = client.get(self.url_3)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        serializer = TestResultSerializer(self.test_3, context={"request": response.wsgi_request})
         self.assertEqual(response.data, serializer.data)
 
     def test_get_invalid(self):
@@ -825,7 +835,7 @@ class TestResultApiTest(ApiTestCase):
     def test_delete(self):
         response = client.delete(self.url_1)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(TestResult.objects.count(), 1)
+        self.assertEqual(TestResult.objects.count(), 2)
 
 class TestResultHistoryApiTest(ApiTestCase):
     def setUp(self):
@@ -981,7 +991,7 @@ class ProjectTestResultsApiTest(ApiTestCase):
         self.assertEqual(response.data, serializer.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-class TestResultApiTest(ApiTestCase):
+class ProjectTestResultApiTest(ApiTestCase):
     def setUp(self):
         super().setUp()
         _, data = self.create_project("Test Project", "test-project")


### PR DESCRIPTION
Just very basic support for now. Does not support deleting entries in the test result array yet. Only deleting and modifying entries is supported.

Additionally this fixes handling TestResults where the `results`  entry is not set at all (is `None`) and fixes CI by upgrading Python.