### PR TITLE
Fix building documentation in CI

### DIFF
--- a/.github/workflows/build_sphinx.yml
+++ b/.github/workflows/build_sphinx.yml
@@ -1,7 +1,6 @@
 
-name: "Build Docs"
+name: "Build Documentation"
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
   pull_request:
@@ -15,3 +14,7 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
+    - uses: actions/upload-artifact@v4
+      with:
+        name: documentation
+        path: docs/_build/html/

--- a/.github/workflows/build_sphinx.yml
+++ b/.github/workflows/build_sphinx.yml
@@ -11,7 +11,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"

--- a/.github/workflows/build_sphinx.yml
+++ b/.github/workflows/build_sphinx.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: ammaraskar/sphinx-action@master
+    - uses: ammaraskar/sphinx-action@8.1.3
       with:
         docs-folder: "docs/"
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: [3.9, 3.11]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -11,9 +11,9 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      fail-fast: false
       matrix:
-        python-version: [3.9, 3.11]
+        python-version: [3.9, 3.11, 3.13]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -12,17 +12,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    # Standard drop-in approach that should work for most people.
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
-    # Create an artifact of the html output.
-    - uses: actions/upload-artifact@v4
-      with:
-        name: DocumentationHTML
-        path: docs/_build/html/
-    # Publish built docs to gh-pages branch.
-    # ===============================
     - name: Commit documentation changes
       run: |
         git clone https://github.com/albertziegenhagel/django-testing-framework.git --branch gh-pages --single-branch gh-pages
@@ -40,4 +32,3 @@ jobs:
         branch: gh-pages
         directory: gh-pages
         github_token: ${{ secrets.GITHUB_TOKEN }}
-    # ===============================

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: ammaraskar/sphinx-action@master
+    - uses: ammaraskar/sphinx-action@8.1.3
       with:
         docs-folder: "docs/"
     - name: Commit documentation changes


### PR DESCRIPTION
The CI used a very old Sphinx version, which was incompatible with other up-to-data packaged used.
It was upgraded to the last (8.1.4).

Additional cleanups of the CI workflows were done.